### PR TITLE
修复 内存泄漏风险 (AI-DataFlux.py:82-89) 

### DIFF
--- a/AI-DataFlux.py
+++ b/AI-DataFlux.py
@@ -828,8 +828,8 @@ class UniversalAIProcessor:
                     for completed_task in done:
                         try:
                             result = completed_task.result()
-                            record_id, original_data = task_id_map.pop(completed_task)
-                            
+                            record_id, _ = task_id_map.pop(completed_task)  # data不再使用，改用reload
+
                             # 标记任务已完成处理 (无论成功还是失败)
                             self.mark_task_completed(record_id)
                             
@@ -971,7 +971,7 @@ class UniversalAIProcessor:
                         except Exception as e:
                             # 任务执行过程中发生异常
                             try:
-                                record_id, original_data = task_id_map.pop(completed_task, (None, None))
+                                record_id, _ = task_id_map.pop(completed_task, (None, None))  # data不再使用，改用reload
                                 if record_id is not None:
                                     # 确保任务被标记为已完成，即使出错
                                     self.mark_task_completed(record_id)


### PR DESCRIPTION
此 pull request 重构了 `AI-DataFlux.py` 中的任务重试机制，通过移除原始任务数据的内存中缓存来提高可靠性和一致性。取而代之的是，系统现在每次重试时都直接从数据源重新加载原始数据。此更改确保重试始终使用最新的数据，并消除了缓存数据陈旧或丢失的问题。此外，`Flux_Data.py` 中重新加载任务数据时的线程安全性得到了增强。

**任务数据处理和重试逻辑：**

  * 从 `TaskMetadata` 类中移除了 `original_data` 属性和所有相关的缓存方法，因此原始任务数据不再存储在内存中。 (`AI-DataFlux.py`) 
  * 更新了所有重试逻辑，通过 `reload_task_data` 从数据源重新加载原始数据，而不是使用缓存数据。如果数据重新加载失败，任务将被标记为永久失败，并记录错误详情。 (`AI-DataFlux.py`) 
**线程安全改进：**
  * 在 `reload_task_data` 的数据重新加载操作周围添加了一个锁，以防止与并发写入操作发生竞态条件。 (`Flux_Data.py`)