### PR TITLE
Harden gateway parsing, config validation, and CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,14 +243,13 @@ jobs:
           "
 
   # =========================================================================
-  # 集成测试（可选）— 仅在手动触发 (workflow_dispatch) 时运行
-  # 需要外部服务依赖（如 API 端点），因此不在普通 CI 中运行
+  # 集成测试 — 在 PR/push/手动触发时运行
+  # 当前集成测试只使用本地临时文件和本地数据源，不依赖外部服务。
   # =========================================================================
-  # 集成测试 (可选)
+  # 集成测试
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 

--- a/cli.py
+++ b/cli.py
@@ -181,9 +181,20 @@ def cmd_process(args):
 
     if args.validate:
         _check_rlimit()
-        from src.config import load_config
+        from src.config import load_config, validate_config
 
         config = load_config(args.config)
+        validation = validate_config(config, args.config)
+
+        for warning in validation["warnings"]:
+            print(f"{console.warn} {warning}")
+
+        if validation["errors"]:
+            print(f"{console.error} Config invalid: {args.config}")
+            for error in validation["errors"]:
+                print(f"  - {error}")
+            return 1
+
         print(f"{console.ok} Config valid: {args.config}")
         print(f"  - Datasource: {config.get('datasource', {}).get('type', 'excel')}")
         print(f"  - Engine: {config.get('datasource', {}).get('engine', 'auto')}")

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1280,10 +1280,41 @@ datasource:
 
 ### 配置验证
 
-**位置**：各组件初始化时验证
+配置验证分为两层：
+
+1. **统一语义校验**：`src/config/settings.py:validate_config()` 在启动前检查 YAML 结构和会导致运行失败的配置语义。
+2. **组件初始化校验**：各数据源或处理组件在真正初始化时继续校验文件存在性、数据库连接参数等运行期条件。
+
+可通过以下入口触发统一语义校验：
+
+```bash
+python cli.py process --config config.yaml --validate
+python main.py --config config.yaml --validate
+```
+
+GUI 控制面板的 `POST /api/config/validate` 也调用同一套 `validate_config()`，并返回 `errors` 与 `warnings`。
+
+统一语义校验会拦截：
+
+- 不支持的 `datasource.type`
+- 非法的 engine、Excel reader/writer、log 选项
+- 非 bool 或非正整数的并发/开关配置
+- 空或类型错误的 `columns_to_extract` / `columns_to_write`
+- 主配置缺少 `prompt.template`
+- 数据源必需字段缺失，例如 Excel/CSV `input_path`、SQLite `db_path/table_name`、MySQL/PostgreSQL 连接字段、Feishu 凭证与表格标识
+- routing 启用时缺少 `field`、`subtasks`、`match`、`profile`，或 profile 文件不存在
+- routing profile 包含 `prompt` / `validation` 之外的顶层键
+
+以下情况返回 warning，不阻止配置通过：
+
+- 未识别的顶层配置键
+- 旧版但当前处理引擎不会读取的并发键：`max_workers`、`retry_times`、`backoff_factor`
+
+**组件初始化校验位置**：
 
 | 组件 | 验证内容 | 代码位置 |
 |------|---------|---------|
+| 统一配置校验 | 启动前语义配置、routing profile、旧键 warning | `src/config/settings.py:validate_config()` |
 | UniversalAIProcessor | flux_api_url 必需 | `src/core/processor.py:59-60` |
 | MySQLTaskPool | host/user/password/database/table_name 必需 | `src/data/factory.py:155-158` |
 | PostgreSQLTaskPool | host/user/password/database/table_name 必需 | `src/data/factory.py:243-245` |

--- a/docs/GUI.md
+++ b/docs/GUI.md
@@ -107,7 +107,7 @@ python cli.py gui
 |------|------|------|
 | `GET` | `/api/config?path=config.yaml` | 读取配置文件内容（仅允许 `.yaml/.yml`） |
 | `PUT` | `/api/config` | 写入配置文件（自动备份） |
-| `POST` | `/api/config/validate` | 校验 YAML 语法（仅解析，不做业务校验） |
+| `POST` | `/api/config/validate` | 校验 YAML 语法和运行前语义配置 |
 
 **PUT /api/config 请求体**:
 ```json
@@ -120,16 +120,21 @@ python cli.py gui
 **POST /api/config/validate 请求体**:
 ```json
 {
+  "path": "config.yaml",
   "content": "# YAML content..."
 }
 ```
+
+`path` 用于解析 routing profile 等相对路径；如果省略，则只校验不依赖文件位置的配置项。
 
 **POST /api/config/validate 响应**:
 
 成功：
 ```json
 {
-  "valid": true
+  "valid": true,
+  "errors": [],
+  "warnings": []
 }
 ```
 
@@ -137,9 +142,12 @@ python cli.py gui
 ```json
 {
   "valid": false,
-  "error": "..."
+  "errors": ["datasource.type 不支持: mongodb"],
+  "warnings": ["datasource.concurrency.max_workers 是旧配置键，当前处理引擎不会读取"]
 }
 ```
+
+语义校验覆盖数据源类型、引擎/读写器选项、并发参数、必需数据源字段、`columns_to_extract`/`columns_to_write`、主配置 `prompt.template`、routing 规则和 profile 文件。未知顶层键和已知旧配置键以 warning 返回，不会阻止保存。
 
 ### 进程管理 API
 

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ AI-DataFlux 数据处理引擎主入口模块
 
 依赖模块:
     - src.core.UniversalAIProcessor: 核心处理器
-    - src.config.load_config: 配置加载器（仅验证模式）
+    - src.config.load_config / validate_config: 配置加载与语义校验
 
 函数清单:
     main() -> int
@@ -101,10 +101,21 @@ def main() -> int:
 
     try:
         if args.validate:
-            # 验证模式：仅加载配置并显示关键信息
-            from src.config import load_config
+            # 验证模式：加载配置并检查本地可验证的运行前置条件
+            from src.config import load_config, validate_config
 
             config = load_config(args.config)
+            validation = validate_config(config, args.config)
+
+            for warning in validation["warnings"]:
+                print(f"⚠ {warning}")
+
+            if validation["errors"]:
+                print(f"✗ 配置文件无效: {args.config}")
+                for error in validation["errors"]:
+                    print(f"  - {error}")
+                return 1
+
             print(f"✓ 配置文件有效: {args.config}")
             print(
                 f"  - 数据源类型: {config.get('datasource', {}).get('type', 'excel')}"

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -14,6 +14,8 @@
             深度合并两个配置字典 (override 覆盖 base)
         get_nested(config: dict, *keys: str, default=None) -> Any
             安全获取嵌套字典值 (任意层级不存在返回默认值)
+        validate_config(config, config_path=None) -> dict
+            校验配置结构和本地可验证的运行前置条件
     常量:
         DEFAULT_CONFIG: dict[str, Any]
             默认配置字典 (包含 global、datasource、token_estimation 等默认值)
@@ -37,6 +39,7 @@ from .settings import (
     DEFAULT_CONFIG,
     merge_config,
     get_nested,
+    validate_config,
 )
 
 __all__ = [
@@ -45,4 +48,5 @@ __all__ = [
     "DEFAULT_CONFIG",
     "merge_config",
     "get_nested",
+    "validate_config",
 ]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -135,6 +135,41 @@ DEFAULT_CONFIG: dict[str, Any] = {
     },
 }
 
+SUPPORTED_DATASOURCE_TYPES = {
+    "excel",
+    "csv",
+    "mysql",
+    "postgresql",
+    "sqlite",
+    "feishu_bitable",
+    "feishu_sheet",
+}
+SUPPORTED_ENGINES = {"auto", "pandas", "polars"}
+SUPPORTED_EXCEL_READERS = {"auto", "openpyxl", "calamine"}
+SUPPORTED_EXCEL_WRITERS = {"auto", "openpyxl", "xlsxwriter"}
+SUPPORTED_LOG_LEVELS = {"debug", "info", "warning", "error"}
+SUPPORTED_LOG_FORMATS = {"text", "json"}
+SUPPORTED_LOG_OUTPUTS = {"console", "file"}
+ALLOWED_TOP_LEVEL_KEYS = {
+    "global",
+    "gateway",
+    "datasource",
+    "mysql",
+    "excel",
+    "postgresql",
+    "sqlite",
+    "csv",
+    "feishu",
+    "columns_to_extract",
+    "columns_to_write",
+    "validation",
+    "models",
+    "channels",
+    "prompt",
+    "token_estimation",
+    "routing",
+}
+
 
 def load_config(config_path: str | Path) -> dict[str, Any]:
     """
@@ -174,6 +209,405 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
         raise ConfigError(f"YAML 解析错误: {e}") from e
     except Exception as e:
         raise ConfigError(f"加载配置文件失败: {e}") from e
+
+
+def validate_config(
+    config: dict[str, Any], config_path: str | Path | None = None
+) -> dict[str, list[str]]:
+    """
+    校验配置结构和本地可验证的运行前置条件。
+
+    本函数不连接数据库、不访问远端 API，也不要求输入数据文件已经存在；
+    它只拦截会在启动初始化阶段立即失败的配置错误，并提示已知会被忽略的旧键。
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not isinstance(config, dict):
+        return {"errors": ["配置根节点必须是字典"], "warnings": warnings}
+
+    unknown_top_level = sorted(set(config) - ALLOWED_TOP_LEVEL_KEYS)
+    if unknown_top_level:
+        warnings.append(f"发现未知顶层配置键，将被忽略: {unknown_top_level}")
+
+    _validate_global_config(config.get("global", {}), errors, warnings)
+    datasource = _ensure_mapping(config.get("datasource", {}), "datasource", errors)
+    datasource_type = (
+        _normalize_nonempty_str(datasource.get("type")) or "excel"
+    ).lower()
+    if datasource_type not in SUPPORTED_DATASOURCE_TYPES:
+        errors.append(
+            f"datasource.type 不支持: {datasource_type!r}，"
+            f"可选: {sorted(SUPPORTED_DATASOURCE_TYPES)}"
+        )
+
+    _validate_datasource_options(datasource, errors, warnings)
+    _validate_columns_config(config, errors)
+    _validate_prompt_config(config.get("prompt", {}), "prompt", errors)
+    _validate_validation_config(config.get("validation", {}), "validation", errors)
+    _validate_data_source_section(config, datasource_type, errors)
+    _validate_routing_config(config, config_path, errors)
+
+    return {"errors": errors, "warnings": warnings}
+
+
+def _normalize_nonempty_str(value: Any) -> str | None:
+    """将配置值规范化为非空字符串。"""
+    if value is None or isinstance(value, bool):
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def _ensure_mapping(value: Any, path: str, errors: list[str]) -> dict[str, Any]:
+    """确认配置节点为 dict；否则记录错误并返回空 dict。"""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"{path} 必须是字典")
+        return {}
+    return value
+
+
+def _validate_global_config(
+    global_cfg: Any, errors: list[str], warnings: list[str]
+) -> None:
+    global_map = _ensure_mapping(global_cfg, "global", errors)
+    log_cfg = _ensure_mapping(global_map.get("log", {}), "global.log", errors)
+
+    level = _normalize_nonempty_str(log_cfg.get("level"))
+    if level is not None and level.lower() not in SUPPORTED_LOG_LEVELS:
+        errors.append(
+            f"global.log.level 不支持: {level!r}，可选: {sorted(SUPPORTED_LOG_LEVELS)}"
+        )
+
+    fmt = _normalize_nonempty_str(log_cfg.get("format"))
+    if fmt is not None and fmt.lower() not in SUPPORTED_LOG_FORMATS:
+        errors.append(
+            f"global.log.format 不支持: {fmt!r}，可选: {sorted(SUPPORTED_LOG_FORMATS)}"
+        )
+
+    output = _normalize_nonempty_str(log_cfg.get("output"))
+    if output is not None and output.lower() not in SUPPORTED_LOG_OUTPUTS:
+        errors.append(
+            f"global.log.output 不支持: {output!r}，可选: {sorted(SUPPORTED_LOG_OUTPUTS)}"
+        )
+
+    if output == "file" and not _normalize_nonempty_str(log_cfg.get("file_path")):
+        warnings.append("global.log.output=file 但未设置 file_path，将使用默认日志路径")
+
+
+def _validate_datasource_options(
+    datasource: dict[str, Any], errors: list[str], warnings: list[str]
+) -> None:
+    engine = _normalize_nonempty_str(datasource.get("engine")) or "auto"
+    if engine not in SUPPORTED_ENGINES:
+        errors.append(
+            f"datasource.engine 不支持: {engine!r}，可选: {sorted(SUPPORTED_ENGINES)}"
+        )
+
+    reader = _normalize_nonempty_str(datasource.get("excel_reader")) or "auto"
+    if reader not in SUPPORTED_EXCEL_READERS:
+        errors.append(
+            f"datasource.excel_reader 不支持: {reader!r}，"
+            f"可选: {sorted(SUPPORTED_EXCEL_READERS)}"
+        )
+
+    writer = _normalize_nonempty_str(datasource.get("excel_writer")) or "auto"
+    if writer not in SUPPORTED_EXCEL_WRITERS:
+        errors.append(
+            f"datasource.excel_writer 不支持: {writer!r}，"
+            f"可选: {sorted(SUPPORTED_EXCEL_WRITERS)}"
+        )
+
+    if "require_all_input_fields" in datasource and not isinstance(
+        datasource["require_all_input_fields"], bool
+    ):
+        errors.append("datasource.require_all_input_fields 必须是布尔值")
+
+    concurrency = _ensure_mapping(
+        datasource.get("concurrency", {}), "datasource.concurrency", errors
+    )
+    _validate_positive_int(concurrency, "batch_size", "datasource.concurrency", errors)
+    _validate_positive_int(
+        concurrency, "save_interval", "datasource.concurrency", errors
+    )
+    _validate_positive_int(concurrency, "shard_size", "datasource.concurrency", errors)
+    _validate_positive_int(
+        concurrency, "min_shard_size", "datasource.concurrency", errors
+    )
+    _validate_positive_int(
+        concurrency, "max_shard_size", "datasource.concurrency", errors
+    )
+    _validate_positive_int(
+        concurrency, "max_connections", "datasource.concurrency", errors
+    )
+    _validate_nonnegative_int(
+        concurrency, "max_connections_per_host", "datasource.concurrency", errors
+    )
+    _validate_positive_number(
+        concurrency, "api_pause_duration", "datasource.concurrency", errors
+    )
+    _validate_positive_number(
+        concurrency, "api_error_trigger_window", "datasource.concurrency", errors
+    )
+
+    min_shard = concurrency.get("min_shard_size")
+    max_shard = concurrency.get("max_shard_size")
+    if (
+        isinstance(min_shard, int)
+        and isinstance(max_shard, int)
+        and min_shard > max_shard
+    ):
+        errors.append("datasource.concurrency.min_shard_size 不能大于 max_shard_size")
+
+    retry_limits = _ensure_mapping(
+        concurrency.get("retry_limits", {}),
+        "datasource.concurrency.retry_limits",
+        errors,
+    )
+    for key in ("api_error", "content_error", "system_error"):
+        _validate_nonnegative_int(
+            retry_limits, key, "datasource.concurrency.retry_limits", errors
+        )
+
+    ignored_keys = sorted(
+        set(concurrency).intersection({"max_workers", "retry_times", "backoff_factor"})
+    )
+    for key in ignored_keys:
+        warnings.append(
+            f"datasource.concurrency.{key} 是旧配置键，当前处理引擎不会读取"
+        )
+
+
+def _validate_columns_config(config: dict[str, Any], errors: list[str]) -> None:
+    columns_to_extract = config.get("columns_to_extract")
+    if not isinstance(columns_to_extract, list) or not columns_to_extract:
+        errors.append("columns_to_extract 必须是非空列表")
+    elif not all(_normalize_nonempty_str(item) for item in columns_to_extract):
+        errors.append("columns_to_extract 中的每一项都必须是非空字符串")
+
+    columns_to_write = config.get("columns_to_write")
+    if not isinstance(columns_to_write, dict) or not columns_to_write:
+        errors.append("columns_to_write 必须是非空字典")
+    else:
+        invalid_items = [
+            key
+            for key, value in columns_to_write.items()
+            if not _normalize_nonempty_str(key) or not _normalize_nonempty_str(value)
+        ]
+        if invalid_items:
+            errors.append(
+                f"columns_to_write 的键和值都必须是非空字符串，异常键: {invalid_items}"
+            )
+
+
+def _validate_prompt_config(
+    value: Any, path: str, errors: list[str], *, require_template: bool = True
+) -> None:
+    prompt = _ensure_mapping(value, path, errors)
+
+    template = _normalize_nonempty_str(prompt.get("template"))
+    if require_template:
+        if not template:
+            errors.append(f"{path}.template 必须是非空字符串")
+    elif "template" in prompt and not template:
+        errors.append(f"{path}.template 必须是非空字符串")
+
+    if "required_fields" in prompt:
+        required_fields = prompt["required_fields"]
+        if not isinstance(required_fields, list):
+            errors.append(f"{path}.required_fields 必须是列表")
+        elif not all(_normalize_nonempty_str(item) for item in required_fields):
+            errors.append(f"{path}.required_fields 中的每一项都必须是非空字符串")
+
+    if "use_json_schema" in prompt and not isinstance(prompt["use_json_schema"], bool):
+        errors.append(f"{path}.use_json_schema 必须是布尔值")
+
+
+def _validate_validation_config(value: Any, path: str, errors: list[str]) -> None:
+    validation = _ensure_mapping(value, path, errors)
+    if "enabled" in validation and not isinstance(validation["enabled"], bool):
+        errors.append(f"{path}.enabled 必须是布尔值")
+
+    if "field_rules" not in validation:
+        return
+
+    field_rules = validation["field_rules"]
+    if not isinstance(field_rules, dict):
+        errors.append(f"{path}.field_rules 必须是字典")
+        return
+
+    invalid_rules = [
+        key for key, values in field_rules.items() if not isinstance(values, list)
+    ]
+    if invalid_rules:
+        errors.append(
+            f"{path}.field_rules 的规则值必须是列表，异常字段: {invalid_rules}"
+        )
+
+
+def _validate_data_source_section(
+    config: dict[str, Any], datasource_type: str, errors: list[str]
+) -> None:
+    if datasource_type in {"excel", "csv"}:
+        section = _ensure_mapping(
+            config.get(datasource_type, {}), datasource_type, errors
+        )
+        if not _normalize_nonempty_str(section.get("input_path")):
+            errors.append(f"{datasource_type}.input_path 是必填项")
+        return
+
+    if datasource_type == "sqlite":
+        sqlite = _ensure_mapping(config.get("sqlite", {}), "sqlite", errors)
+        for key in ("db_path", "table_name"):
+            if not _normalize_nonempty_str(sqlite.get(key)):
+                errors.append(f"sqlite.{key} 是必填项")
+        return
+
+    if datasource_type in {"mysql", "postgresql"}:
+        section = _ensure_mapping(
+            config.get(datasource_type, {}), datasource_type, errors
+        )
+        for key in ("host", "user", "password", "database", "table_name"):
+            if not _normalize_nonempty_str(section.get(key)):
+                errors.append(f"{datasource_type}.{key} 是必填项")
+        return
+
+    if datasource_type in {"feishu_bitable", "feishu_sheet"}:
+        feishu = _ensure_mapping(config.get("feishu", {}), "feishu", errors)
+        datasource = _ensure_mapping(config.get("datasource", {}), "datasource", errors)
+        for key in ("app_id", "app_secret"):
+            if not _normalize_nonempty_str(feishu.get(key)):
+                errors.append(f"feishu.{key} 是必填项")
+
+        if datasource_type == "feishu_bitable":
+            app_token = _normalize_nonempty_str(feishu.get("app_token"))
+            app_token = app_token or _normalize_nonempty_str(
+                datasource.get("app_token")
+            )
+            table_id = _normalize_nonempty_str(feishu.get("table_id"))
+            table_id = table_id or _normalize_nonempty_str(datasource.get("table_id"))
+            if app_token is None:
+                errors.append(
+                    "feishu_bitable 需要 feishu.app_token 或 datasource.app_token"
+                )
+            if table_id is None:
+                errors.append(
+                    "feishu_bitable 需要 feishu.table_id 或 datasource.table_id"
+                )
+        else:
+            spreadsheet_token = _normalize_nonempty_str(feishu.get("spreadsheet_token"))
+            spreadsheet_token = spreadsheet_token or _normalize_nonempty_str(
+                datasource.get("spreadsheet_token")
+            )
+            sheet_id = _normalize_nonempty_str(feishu.get("sheet_id"))
+            sheet_id = sheet_id or _normalize_nonempty_str(datasource.get("sheet_id"))
+            if spreadsheet_token is None:
+                errors.append(
+                    "feishu_sheet 需要 feishu.spreadsheet_token 或 datasource.spreadsheet_token"
+                )
+            if sheet_id is None:
+                errors.append(
+                    "feishu_sheet 需要 feishu.sheet_id 或 datasource.sheet_id"
+                )
+
+
+def _validate_routing_config(
+    config: dict[str, Any], config_path: str | Path | None, errors: list[str]
+) -> None:
+    routing = _ensure_mapping(config.get("routing", {}), "routing", errors)
+    enabled = routing.get("enabled", False)
+    if not isinstance(enabled, bool):
+        errors.append("routing.enabled 必须是布尔值")
+        return
+    if not enabled:
+        return
+
+    field = _normalize_nonempty_str(routing.get("field"))
+    if not field:
+        errors.append("routing.enabled=true 时必须配置 routing.field")
+
+    subtasks = routing.get("subtasks")
+    if not isinstance(subtasks, list) or not subtasks:
+        errors.append("routing.enabled=true 时 routing.subtasks 必须是非空列表")
+        return
+
+    base_dir = Path(config_path).parent if config_path is not None else Path.cwd()
+    for idx, subtask in enumerate(subtasks):
+        if not isinstance(subtask, dict):
+            errors.append(f"routing.subtasks[{idx}] 必须是字典")
+            continue
+
+        if "match" not in subtask:
+            errors.append(f"routing.subtasks[{idx}] 必须包含 match")
+
+        profile = _normalize_nonempty_str(subtask.get("profile"))
+        if profile is None:
+            errors.append(f"routing.subtasks[{idx}] 必须包含非空 profile")
+            continue
+
+        profile_path = Path(profile)
+        if not profile_path.is_absolute():
+            profile_path = base_dir / profile_path
+
+        try:
+            profile_config = load_config(profile_path)
+        except Exception as exc:
+            errors.append(f"routing.subtasks[{idx}].profile 加载失败: {exc}")
+            continue
+
+        unknown_keys = sorted(set(profile_config) - {"prompt", "validation"})
+        if unknown_keys:
+            errors.append(
+                f"routing.subtasks[{idx}].profile 仅允许 prompt/validation，"
+                f"发现非法键: {unknown_keys}"
+            )
+            continue
+
+        if "prompt" in profile_config:
+            _validate_prompt_config(
+                profile_config["prompt"],
+                f"routing.subtasks[{idx}].profile.prompt",
+                errors,
+                require_template=False,
+            )
+        if "validation" in profile_config:
+            _validate_validation_config(
+                profile_config["validation"],
+                f"routing.subtasks[{idx}].profile.validation",
+                errors,
+            )
+
+
+def _validate_positive_int(
+    mapping: dict[str, Any], key: str, path: str, errors: list[str]
+) -> None:
+    if key not in mapping:
+        return
+    value = mapping[key]
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        errors.append(f"{path}.{key} 必须是大于 0 的整数")
+
+
+def _validate_nonnegative_int(
+    mapping: dict[str, Any], key: str, path: str, errors: list[str]
+) -> None:
+    if key not in mapping:
+        return
+    value = mapping[key]
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        errors.append(f"{path}.{key} 必须是大于等于 0 的整数")
+
+
+def _validate_positive_number(
+    mapping: dict[str, Any], key: str, path: str, errors: list[str]
+) -> None:
+    if key not in mapping:
+        return
+    value = mapping[key]
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+        errors.append(f"{path}.{key} 必须是大于 0 的数字")
 
 
 def init_logging(log_config: dict[str, Any] | None = None) -> None:

--- a/src/control/server.py
+++ b/src/control/server.py
@@ -62,7 +62,7 @@ Pydantic 请求模型:
     REST API 路由:
         GET  /api/config              - 读取配置文件
         PUT  /api/config              - 写入配置文件
-        POST /api/config/validate     - 校验 YAML 语法
+        POST /api/config/validate     - 校验 YAML 语法和本地可验证的配置语义
         POST /api/feishu/test_connection - 测试飞书连接
         POST /api/gateway/start       - 启动 Gateway
         POST /api/gateway/stop        - 停止 Gateway
@@ -296,6 +296,7 @@ class ConfigValidateRequest(BaseModel):
     """配置文件校验请求"""
 
     content: str
+    path: str = "config.yaml"
 
 
 class GatewayStartRequest(BaseModel):
@@ -618,14 +619,28 @@ def create_control_app() -> FastAPI:
 
     @app.post("/api/config/validate")
     async def api_validate_config(request: ConfigValidateRequest):
-        """校验 YAML 配置内容（仅语法/解析）"""
+        """校验 YAML 配置内容（语法和本地可验证的运行前置条件）"""
         import yaml
+        from src.config import validate_config
 
         try:
-            yaml.safe_load(request.content)
-            return {"valid": True}
+            parsed = yaml.safe_load(request.content)
         except yaml.YAMLError as e:
-            return {"valid": False, "error": str(e)}
+            return {"valid": False, "error": str(e), "errors": [str(e)], "warnings": []}
+
+        validation = validate_config(parsed, request.path)
+        if validation["errors"]:
+            return {
+                "valid": False,
+                "error": "\n".join(validation["errors"]),
+                "errors": validation["errors"],
+                "warnings": validation["warnings"],
+            }
+
+        return {
+            "valid": True,
+            "warnings": validation["warnings"],
+        }
 
     @app.post("/api/feishu/test_connection")
     async def api_feishu_test_connection(request: FeishuTestConnectionRequest):

--- a/src/core/content/processor.py
+++ b/src/core/content/processor.py
@@ -226,10 +226,17 @@ class ContentProcessor:
 
         # 3. 提取所有平衡的 JSON 对象候选。这里不能用非贪婪正则，
         # 否则遇到嵌套对象时会在第一个右花括号处截断。
+        first_validation_error = None
         for candidate in self._iter_json_object_candidates(content):
             validation_result = self._validate_candidate(candidate)
             if validation_result is not None:
+                if validation_result.get("_error") == "invalid_field_values":
+                    first_validation_error = first_validation_error or validation_result
+                    continue
                 return validation_result
+
+        if first_validation_error is not None:
+            return first_validation_error
 
         logging.error(f"无法提取有效 JSON (必需字段: {self.required_fields})")
         return {"_error": "invalid_or_missing_json", "_error_type": ErrorType.CONTENT}

--- a/src/core/content/processor.py
+++ b/src/core/content/processor.py
@@ -14,7 +14,7 @@
           将记录数据渲染为 Prompt (过滤 _开头字段、None 值、排除字段)
           输入: Dict 原始记录数据 | 输出: str 渲染后的 Prompt 字符串
         - parse_response(content: Optional[str]) -> Dict
-          从 AI 响应提取 JSON，三级回退策略 (Markdown → 直接解析 → 正则)
+          从 AI 响应提取 JSON，三级回退策略 (Markdown → 直接解析 → 平衡对象扫描)
           输入: str|None AI 响应文本 | 输出: Dict 解析结果或错误字典
         - _check_missing_fields(data: Dict) -> List[str]
           检查数据中缺失的必需字段
@@ -32,7 +32,7 @@
 
 模块依赖:
     - json: JSON 序列化与解析
-    - re: 正则表达式 (Markdown 代码块提取、JSON 搜索、尾逗号清理)
+    - re: 正则表达式 (Markdown 代码块提取、尾逗号清理)
     - logging: 错误日志
     - src.core.validator.JsonValidator: 字段枚举值验证
     - src.models.errors.ErrorType: 错误类型常量
@@ -53,7 +53,7 @@
 JSON 提取策略 (按优先级):
     1. Markdown 代码块: ```json {...} ``` 或 ``` {...} ```
     2. 直接 JSON 解析: 整个响应作为 JSON
-    3. 正则提取: 搜索所有 {...} 模式，逐个尝试解析
+    3. 平衡对象扫描: 搜索所有完整 {...} 候选，逐个尝试解析
 
 JSON 预处理:
     - 移除尾部多余逗号 (常见的 AI 错误): {"a": 1,} → {"a": 1}
@@ -195,7 +195,7 @@ class ContentProcessor:
         提取策略:
             1. 尝试提取 Markdown JSON 代码块 (```json...```)
             2. 尝试直接解析整个响应为 JSON
-            3. 使用正则搜索所有 {...} 模式
+            3. 扫描所有平衡的 JSON 对象候选
 
         错误类型:
             - empty_ai_response: AI 返回空内容
@@ -217,46 +217,101 @@ class ContentProcessor:
             parse_content = code_block_match.group(1).strip()
 
         # 2. 尝试直接解析
-        # 预处理：移除尾部多余的逗号 (常见的 AI 格式错误)
-        try:
-            parse_content_cleaned = re.sub(r",\s*([}\]])", r"\1", parse_content)
-            data = json.loads(parse_content_cleaned)
+        data = self._load_json_object(parse_content)
+        if data is not None:
+            validation_result = self._validate_candidate(data)
+            if validation_result is not None:
+                return validation_result
+            # 如果缺少字段，继续尝试从原始文本中提取其他 JSON 对象
 
-            if isinstance(data, dict):
-                missing_fields = self._check_missing_fields(data)
-                if not missing_fields:
-                    # 字段完整，进行值验证
-                    is_valid, errors = self.validator.validate(data)
-                    if is_valid:
-                        return data
-                    else:
-                        return {
-                            "_error": "invalid_field_values",
-                            "_error_type": ErrorType.CONTENT,
-                            "_validation_errors": errors,
-                        }
-                # 如果缺少字段，继续尝试正则提取
-        except json.JSONDecodeError:
-            pass
-
-        # 3. 尝试正则提取所有可能的 JSON 对象
-        pattern = r"(\{.*?\})"
-        for match in re.finditer(pattern, content, re.DOTALL):
-            match_str = match.group(1)
-            try:
-                match_str_cleaned = re.sub(r",\s*([}\]])", r"\1", match_str.strip())
-                candidate = json.loads(match_str_cleaned)
-
-                if isinstance(candidate, dict):
-                    if not self._check_missing_fields(candidate):
-                        is_valid, _ = self.validator.validate(candidate)
-                        if is_valid:
-                            return candidate
-            except json.JSONDecodeError:
-                continue
+        # 3. 提取所有平衡的 JSON 对象候选。这里不能用非贪婪正则，
+        # 否则遇到嵌套对象时会在第一个右花括号处截断。
+        for candidate in self._iter_json_object_candidates(content):
+            validation_result = self._validate_candidate(candidate)
+            if validation_result is not None:
+                return validation_result
 
         logging.error(f"无法提取有效 JSON (必需字段: {self.required_fields})")
         return {"_error": "invalid_or_missing_json", "_error_type": ErrorType.CONTENT}
+
+    def _load_json_object(self, text: str) -> Dict[str, Any] | None:
+        """
+        尝试把文本解析为 JSON 对象。
+
+        会先移除 AI 常见的尾随逗号错误；非对象 JSON（如数组/字符串）返回 None。
+        """
+        try:
+            cleaned = re.sub(r",\s*([}\]])", r"\1", text.strip())
+            data = json.loads(cleaned)
+        except json.JSONDecodeError:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _validate_candidate(self, data: Dict[str, Any]) -> Dict[str, Any] | None:
+        """
+        校验候选 JSON 对象。
+
+        返回 None 表示字段缺失，调用方可以继续尝试其他候选对象。
+        """
+        missing_fields = self._check_missing_fields(data)
+        if missing_fields:
+            return None
+
+        is_valid, errors = self.validator.validate(data)
+        if is_valid:
+            return data
+
+        return {
+            "_error": "invalid_field_values",
+            "_error_type": ErrorType.CONTENT,
+            "_validation_errors": errors,
+        }
+
+    def _iter_json_object_candidates(self, text: str):
+        """按出现顺序产出文本中的平衡 JSON 对象候选。"""
+        seen: set[str] = set()
+        for start, char in enumerate(text):
+            if char != "{":
+                continue
+
+            candidate_text = self._extract_balanced_json_object(text, start)
+            if not candidate_text or candidate_text in seen:
+                continue
+
+            seen.add(candidate_text)
+            candidate = self._load_json_object(candidate_text)
+            if candidate is not None:
+                yield candidate
+
+    @staticmethod
+    def _extract_balanced_json_object(text: str, start: int) -> str | None:
+        """从 start 位置提取一个平衡的 JSON 对象字符串。"""
+        depth = 0
+        in_string = False
+        escaped = False
+
+        for pos in range(start, len(text)):
+            char = text[pos]
+
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+
+            if char == '"':
+                in_string = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : pos + 1]
+
+        return None
 
     def _check_missing_fields(self, data: Dict[str, Any]) -> List[str]:
         """

--- a/src/core/content/processor.py
+++ b/src/core/content/processor.py
@@ -216,21 +216,25 @@ class ContentProcessor:
         if code_block_match:
             parse_content = code_block_match.group(1).strip()
 
+        first_validation_error = None
+
         # 2. 尝试直接解析
         data = self._load_json_object(parse_content)
         if data is not None:
             validation_result = self._validate_candidate(data)
             if validation_result is not None:
-                return validation_result
+                if self._is_invalid_field_error(validation_result):
+                    first_validation_error = validation_result
+                else:
+                    return validation_result
             # 如果缺少字段，继续尝试从原始文本中提取其他 JSON 对象
 
         # 3. 提取所有平衡的 JSON 对象候选。这里不能用非贪婪正则，
         # 否则遇到嵌套对象时会在第一个右花括号处截断。
-        first_validation_error = None
         for candidate in self._iter_json_object_candidates(content):
             validation_result = self._validate_candidate(candidate)
             if validation_result is not None:
-                if validation_result.get("_error") == "invalid_field_values":
+                if self._is_invalid_field_error(validation_result):
                     first_validation_error = first_validation_error or validation_result
                     continue
                 return validation_result
@@ -248,11 +252,16 @@ class ContentProcessor:
         会先移除 AI 常见的尾随逗号错误；非对象 JSON（如数组/字符串）返回 None。
         """
         try:
-            cleaned = re.sub(r",\s*([}\]])", r"\1", text.strip())
+            cleaned = self._strip_trailing_commas(text.strip())
             data = json.loads(cleaned)
         except json.JSONDecodeError:
             return None
         return data if isinstance(data, dict) else None
+
+    @staticmethod
+    def _is_invalid_field_error(result: Dict[str, Any]) -> bool:
+        """判断校验结果是否为字段值非法错误。"""
+        return result.get("_error") == "invalid_field_values"
 
     def _validate_candidate(self, data: Dict[str, Any]) -> Dict[str, Any] | None:
         """
@@ -319,6 +328,47 @@ class ContentProcessor:
                     return text[start : pos + 1]
 
         return None
+
+    @staticmethod
+    def _strip_trailing_commas(text: str) -> str:
+        """
+        移除对象/数组闭合前的尾随逗号，同时保留字符串内容不变。
+
+        不能直接用正则处理整个 JSON 文本，否则字符串值里的 `,}` 或 `,]`
+        会被误删。
+        """
+        result: list[str] = []
+        in_string = False
+        escaped = False
+
+        for char in text:
+            if in_string:
+                result.append(char)
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+
+            if char == '"':
+                in_string = True
+                result.append(char)
+                continue
+
+            if char in "}]":
+                index = len(result) - 1
+                while index >= 0 and result[index].isspace():
+                    index -= 1
+                if index >= 0 and result[index] == ",":
+                    del result[index]
+                result.append(char)
+                continue
+
+            result.append(char)
+
+        return "".join(result)
 
     def _check_missing_fields(self, data: Dict[str, Any]) -> List[str]:
         """

--- a/src/gateway/schemas.py
+++ b/src/gateway/schemas.py
@@ -82,7 +82,7 @@ OpenAI 兼容性:
 """
 
 from typing import Any, Literal
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class ChatMessage(BaseModel):
@@ -113,6 +113,7 @@ class ResponseFormat(BaseModel):
     """
 
     type: str = "text"
+    model_config = ConfigDict(extra="allow")
 
 
 class ChatCompletionRequest(BaseModel):
@@ -154,8 +155,7 @@ class ChatCompletionRequest(BaseModel):
     user: str | None = None
     response_format: ResponseFormat | None = None
 
-    class Config:
-        extra = "allow"  # 允许额外字段
+    model_config = ConfigDict(extra="allow")  # 允许额外字段
 
     @model_validator(mode="before")
     @classmethod

--- a/src/gateway/service.py
+++ b/src/gateway/service.py
@@ -343,6 +343,7 @@ class FluxApiService:
         self,
         requested_model_name: str | None = None,
         exclude_models: list[str] | None = None,
+        requires_json_schema: bool = False,
     ) -> ModelConfig | None:
         """
         获取一个可用的模型
@@ -353,6 +354,7 @@ class FluxApiService:
         Args:
             requested_model_name: 用户请求的模型名称/ID
             exclude_models: 要排除的模型ID列表
+            requires_json_schema: 请求是否需要 JSON 输出能力
 
         Returns:
             可用的模型配置，如果没有可用模型返回 None
@@ -389,8 +391,11 @@ class FluxApiService:
                     # 检查调度器可用性和限流器
                     is_available = self.dispatcher.is_model_available(target_model_id)
                     can_process = self.rate_limiter.can_process(target_model_id)
+                    supports_schema = (
+                        not requires_json_schema or model.supports_json_schema
+                    )
 
-                    if is_available and can_process:
+                    if is_available and can_process and supports_schema:
                         logging.debug(
                             f"使用请求的可用模型: {model.name or target_model_id}"
                         )
@@ -400,6 +405,10 @@ class FluxApiService:
                         logging.warning(
                             f"请求的模型 [{model.name or target_model_id}] 当前不可用/受限。尝试随机选择"
                         )
+                        if requires_json_schema and not model.supports_json_schema:
+                            logging.warning(
+                                f"请求需要 JSON 输出，但模型 [{model.name or target_model_id}] 未声明支持 JSON Schema"
+                            )
                         exclude_set.add(target_model_id)
                         use_random_selection = True
             else:
@@ -419,6 +428,9 @@ class FluxApiService:
                 and model.id not in exclude_set  # 未被排除
                 and self.dispatcher.is_model_available(model.id)  # 调度器可用
                 and self.rate_limiter.can_process(model.id)  # 限流器允许
+                and (
+                    not requires_json_schema or model.supports_json_schema
+                )  # JSON 输出能力匹配
             ]
 
             if not eligible_models:
@@ -451,6 +463,7 @@ class FluxApiService:
         start_time = time.time()
         tried_models: set[str] = set()
         last_error: Exception | None = None
+        requires_json_schema = self._request_requires_json_schema(request)
 
         # 尝试多个模型
         max_retries = min(len(self.models), 3)
@@ -460,6 +473,7 @@ class FluxApiService:
             model = self.get_available_model(
                 requested_model_name=request.model,  # 传递用户请求的模型
                 exclude_models=list(tried_models),
+                requires_json_schema=requires_json_schema,
             )
 
             if not model:
@@ -518,45 +532,11 @@ class FluxApiService:
             ssl_verify=model.ssl_verify, proxy=model.proxy
         )
 
-        # 构建请求
         headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {model.api_key}",
         }
-
-        payload: dict[str, Any] = {
-            "model": model.model,
-            "messages": [m.model_dump() for m in request.messages],
-            "temperature": (
-                request.temperature
-                if request.temperature is not None
-                else model.temperature
-            ),
-            "stream": request.stream or False,
-        }
-
-        # 添加可选参数 (使用 is not None 以支持 0 和 False)
-        if request.max_tokens is not None:
-            payload["max_tokens"] = request.max_tokens
-        if request.response_format is not None:
-            payload["response_format"] = request.response_format.model_dump()
-        if request.stop is not None:
-            payload["stop"] = request.stop
-        if request.top_p is not None:
-            payload["top_p"] = request.top_p
-        if request.user is not None:
-            payload["user"] = request.user
-        if request.n is not None:
-            payload["n"] = request.n
-
-        # 高级参数 (如果模型支持)
-        if model.supports_advanced_params:
-            if request.presence_penalty is not None:
-                payload["presence_penalty"] = request.presence_penalty
-            if request.frequency_penalty is not None:
-                payload["frequency_penalty"] = request.frequency_penalty
-            if request.logit_bias is not None:
-                payload["logit_bias"] = request.logit_bias
+        payload = self._build_upstream_payload(model, request)
 
         # 发送请求
         # 流式请求需要更长的 sock_read 超时
@@ -653,6 +633,91 @@ class FluxApiService:
                 else None
             ),
         )
+
+    @staticmethod
+    def _request_requires_json_schema(request: ChatCompletionRequest) -> bool:
+        """
+        判断请求是否要求 JSON 输出能力。
+
+        目前 OpenAI 兼容请求中 response_format 非 text 时，都需要模型声明支持。
+        """
+        return (
+            request.response_format is not None
+            and request.response_format.type.lower() != "text"
+        )
+
+    def _build_upstream_payload(
+        self, model: ModelConfig, request: ChatCompletionRequest
+    ) -> dict[str, Any]:
+        """
+        构建发送给上游模型 API 的请求体。
+
+        ChatCompletionRequest 允许额外字段；这些字段应透传给上游以保持
+        OpenAI 兼容性，但显式构建的标准字段拥有更高优先级。
+        """
+        payload: dict[str, Any] = {
+            "model": model.model,
+            "messages": [m.model_dump() for m in request.messages],
+            "temperature": (
+                request.temperature
+                if request.temperature is not None
+                else model.temperature
+            ),
+            "stream": request.stream or False,
+        }
+
+        # 添加可选参数 (使用 is not None 以支持 0 和 False)
+        if request.max_tokens is not None:
+            payload["max_tokens"] = request.max_tokens
+        if request.response_format is not None:
+            if model.supports_json_schema:
+                payload["response_format"] = request.response_format.model_dump(
+                    exclude_none=True
+                )
+            else:
+                logging.debug(
+                    f"模型 {model.id} 未声明支持 JSON Schema，跳过 response_format"
+                )
+        if request.stop is not None:
+            payload["stop"] = request.stop
+        if request.top_p is not None:
+            payload["top_p"] = request.top_p
+        if request.user is not None:
+            payload["user"] = request.user
+        if request.n is not None:
+            payload["n"] = request.n
+
+        # 高级参数 (如果模型支持)
+        if model.supports_advanced_params:
+            if request.presence_penalty is not None:
+                payload["presence_penalty"] = request.presence_penalty
+            if request.frequency_penalty is not None:
+                payload["frequency_penalty"] = request.frequency_penalty
+            if request.logit_bias is not None:
+                payload["logit_bias"] = request.logit_bias
+
+        # 透传 Pydantic 额外字段，避免 OpenAI 兼容参数被静默丢弃。
+        for key, value in (request.model_extra or {}).items():
+            if key in payload or value is None:
+                continue
+            payload[key] = self._serialize_payload_value(value)
+
+        return payload
+
+    @classmethod
+    def _serialize_payload_value(cls, value: Any) -> Any:
+        """将额外参数转换为 JSON 可序列化的基础结构。"""
+        if hasattr(value, "model_dump"):
+            return value.model_dump(exclude_none=True)
+        if isinstance(value, dict):
+            return {
+                key: cls._serialize_payload_value(item)
+                for key, item in value.items()
+                if item is not None
+            }
+        if isinstance(value, list):
+            return [cls._serialize_payload_value(item) for item in value]
+        return value
 
     def _extract_peer_ip(
         self, resp: aiohttp.ClientResponse, model: ModelConfig

--- a/src/gateway/service.py
+++ b/src/gateway/service.py
@@ -639,11 +639,12 @@ class FluxApiService:
         """
         判断请求是否要求 JSON 输出能力。
 
-        目前 OpenAI 兼容请求中 response_format 非 text 时，都需要模型声明支持。
+        只有严格的 json_schema response_format 需要模型显式声明支持。
+        json_object 是较宽松的 JSON 模式，保持原有透传行为以避免误排除模型。
         """
         return (
             request.response_format is not None
-            and request.response_format.type.lower() != "text"
+            and request.response_format.type.lower() == "json_schema"
         )
 
     def _build_upstream_payload(
@@ -670,7 +671,10 @@ class FluxApiService:
         if request.max_tokens is not None:
             payload["max_tokens"] = request.max_tokens
         if request.response_format is not None:
-            if model.supports_json_schema:
+            if (
+                request.response_format.type.lower() != "json_schema"
+                or model.supports_json_schema
+            ):
                 payload["response_format"] = request.response_format.model_dump(
                     exclude_none=True
                 )

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,14 +12,25 @@ tests/
 │
 ├── test_cli.py            # CLI 命令行测试
 ├── test_config.py         # 配置加载和验证测试
+├── test_control.py        # Web GUI 控制面板测试
+├── test_csv_pool.py       # CSV 数据源测试
 ├── test_engines.py        # 数据引擎测试 (Pandas/Polars)
 ├── test_factory.py        # 数据源工厂模式测试
+├── test_feishu_client_async.py # 飞书客户端异步测试
+├── test_feishu_pool.py    # 飞书数据源测试
+├── test_gateway_service.py # Gateway 服务测试
 ├── test_integration.py    # 集成测试
 ├── test_models.py         # 数据模型测试 (TaskMetadata/ErrorType)
-├── test_processor.py      # 处理器核心逻辑测试
+├── test_postgresql_pool.py # PostgreSQL 数据源测试
 ├── test_scheduler.py      # 分片调度器测试
+├── test_sqlite_pool.py    # SQLite 数据源测试
 ├── test_token_estimator.py # Token 估算器测试
-└── test_validator.py      # JSON 验证器测试
+├── test_validator.py      # JSON 验证器测试
+└── core/                  # 核心模块子目录测试
+    ├── clients/test_flux_client.py
+    ├── content/test_processor.py
+    ├── retry/test_strategy.py
+    └── state/test_manager.py
 ```
 
 ## 🚀 快速开始
@@ -108,17 +119,17 @@ pytest tests/ --cov=src --cov-report=json
 ### test_cli.py
 - **目的**: 测试 CLI 命令行接口
 - **覆盖**: version, check, process, gateway 命令
-- **测试数量**: 9 个测试
+- **测试数量**: 以 `pytest --collect-only` 为准
 
 ### test_config.py
 - **目的**: 测试配置文件加载和验证
-- **覆盖**: YAML 解析、配置验证、错误处理
-- **测试数量**: 9 个测试
+- **覆盖**: YAML 解析、默认配置合并、统一语义校验、错误和 warning 处理
+- **测试数量**: 以 `pytest --collect-only` 为准
 
 ### test_engines.py
 - **目的**: 测试数据引擎抽象和实现
 - **覆盖**: PandasEngine, PolarsEngine, 引擎工厂
-- **测试数量**: 28 个测试
+- **测试数量**: 以 `pytest --collect-only` 为准
 - **特性**:
   - 引擎自动选择
   - 读写器性能库检测 (Calamine/xlsxwriter)
@@ -127,7 +138,7 @@ pytest tests/ --cov=src --cov-report=json
 ### test_factory.py
 - **目的**: 测试数据源任务池工厂
 - **覆盖**: Excel 池创建、MySQL 池创建、引擎选择
-- **测试数量**: 17 个测试
+- **测试数量**: 以 `pytest --collect-only` 为准
 - **特性**:
   - 多种引擎配置 (auto/pandas/polars)
   - 读写器配置
@@ -136,13 +147,13 @@ pytest tests/ --cov=src --cov-report=json
 ### test_integration.py
 - **目的**: 集成测试多模块协同
 - **覆盖**: Excel 任务池、引擎兼容性、配置到池的完整流程
-- **测试数量**: 7 个测试
-- **标记**: `@pytest.mark.integration`
+- **测试数量**: 以 `pytest --collect-only` 为准
+- **标记**: 文件级 `pytestmark = pytest.mark.integration`
 
 ### test_models.py
 - **目的**: 测试数据模型和数据类
 - **覆盖**: TaskMetadata, ErrorRecord, ErrorType
-- **测试数量**: 21 个测试
+- **测试数量**: 以 `pytest --collect-only` 为准
 - **特性**:
   - 重试计数管理
   - 错误历史记录
@@ -151,7 +162,7 @@ pytest tests/ --cov=src --cov-report=json
 ### test_processor.py
 - **目的**: 测试 AI 处理器核心逻辑
 - **覆盖**: 提示词生成、JSON 提取、Schema 构建、任务状态管理
-- **测试数量**: 23 个测试
+- **测试数量**: 以 `pytest --collect-only` 为准
 - **特性**:
   - Markdown 代码块提取
   - 字段验证
@@ -160,7 +171,7 @@ pytest tests/ --cov=src --cov-report=json
 ### test_scheduler.py
 - **目的**: 测试分片任务调度器
 - **覆盖**: 分片计算、加载、进度跟踪、内存监控
-- **测试数量**: 26 个测试
+- **测试数量**: 以 `pytest --collect-only` 为准
 - **特性**:
   - 动态分片大小计算
   - 空分片跳过
@@ -169,12 +180,12 @@ pytest tests/ --cov=src --cov-report=json
 ### test_token_estimator.py
 - **目的**: 测试 Token 估算器
 - **覆盖**: mode 规范化、输入/输出估算、采样逻辑
-- **测试数量**: 14 个测试
+- **测试数量**: 以 `pytest --collect-only` 为准
 
 ### test_validator.py
 - **目的**: 测试 JSON 字段验证器
 - **覆盖**: 字段规则验证、大小写敏感性、数值类型
-- **测试数量**: 10 个测试
+- **测试数量**: 以 `pytest --collect-only` 为准
 
 ## 🔧 Fixtures 说明
 
@@ -288,8 +299,9 @@ def test_performance(self):
 - 引擎自动选择验证
 
 #### 5. 集成测试 (integration-test)
-- 手动触发 (workflow_dispatch)
-- 完整工作流验证
+- 在 push、pull_request 和 workflow_dispatch 中运行
+- 执行 `pytest tests/ -v -m "integration" --tb=short`
+- 当前集成测试只使用本地临时文件和本地数据源，不依赖外部服务
 
 ### 覆盖率上传
 

--- a/tests/core/content/test_processor.py
+++ b/tests/core/content/test_processor.py
@@ -121,6 +121,26 @@ class TestContentProcessor:
         assert result["status"] == "active"
         assert result["details"]["score"] == 98
 
+    def test_parse_response_prefers_later_valid_json_candidate(
+        self, processor, mock_validator
+    ):
+        """测试前面的 JSON 示例校验失败时继续寻找后续有效结果"""
+        def validate(data):
+            if data.get("status") == "active":
+                return True, []
+            return False, ["Invalid status"]
+
+        mock_validator.validate.side_effect = validate
+        response = """
+        示例（不要使用）: {"name": "Example", "status": "invalid"}
+        实际结果: {"name": "Grace", "status": "active"}
+        """
+
+        result = processor.parse_response(response)
+
+        assert result["name"] == "Grace"
+        assert result["status"] == "active"
+
     def test_parse_response_missing_fields(self, processor):
         response = '{"name": "Eve"}'  # 缺少 status
         result = processor.parse_response(response)

--- a/tests/core/content/test_processor.py
+++ b/tests/core/content/test_processor.py
@@ -125,6 +125,7 @@ class TestContentProcessor:
         self, processor, mock_validator
     ):
         """测试前面的 JSON 示例校验失败时继续寻找后续有效结果"""
+
         def validate(data):
             if data.get("status") == "active":
                 return True, []

--- a/tests/core/content/test_processor.py
+++ b/tests/core/content/test_processor.py
@@ -142,6 +142,45 @@ class TestContentProcessor:
         assert result["name"] == "Grace"
         assert result["status"] == "active"
 
+    def test_parse_response_prefers_later_valid_json_after_invalid_code_block(
+        self, processor, mock_validator
+    ):
+        """测试 Markdown 代码块校验失败时继续寻找后续有效结果"""
+
+        def validate(data):
+            if data.get("status") == "active":
+                return True, []
+            return False, ["Invalid status"]
+
+        mock_validator.validate.side_effect = validate
+        response = """
+        下面是格式示例：
+        ```json
+        {"name": "Example", "status": "invalid"}
+        ```
+        实际结果: {"name": "Heidi", "status": "active"}
+        """
+
+        result = processor.parse_response(response)
+
+        assert result["name"] == "Heidi"
+        assert result["status"] == "active"
+
+    def test_parse_response_trailing_comma_cleanup_preserves_string_content(
+        self, processor
+    ):
+        """测试尾逗号清理不会误删字符串内部的逗号"""
+        response = (
+            '{"name": "literal ,} marker", '
+            '"status": "active", '
+            '"note": "literal ,] marker",}'
+        )
+
+        result = processor.parse_response(response)
+
+        assert result["name"] == "literal ,} marker"
+        assert result["note"] == "literal ,] marker"
+
     def test_parse_response_missing_fields(self, processor):
         response = '{"name": "Eve"}'  # 缺少 status
         result = processor.parse_response(response)

--- a/tests/core/content/test_processor.py
+++ b/tests/core/content/test_processor.py
@@ -100,6 +100,27 @@ class TestContentProcessor:
         result = processor.parse_response(response)
         assert result["name"] == "Dave"
 
+    def test_parse_response_extracts_nested_json_from_mixed_text(self, processor):
+        """测试混合文本中的嵌套 JSON 不会被截断"""
+        response = """
+        处理结果如下：
+        {
+            "name": "Ada",
+            "status": "active",
+            "details": {
+                "score": 98,
+                "reason": "contains nested object"
+            }
+        }
+        请查收。
+        """
+
+        result = processor.parse_response(response)
+
+        assert result["name"] == "Ada"
+        assert result["status"] == "active"
+        assert result["details"]["score"] == 98
+
     def test_parse_response_missing_fields(self, processor):
         response = '{"name": "Eve"}'  # 缺少 status
         result = processor.parse_response(response)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,74 @@ class TestCLI:
         )
         assert result.returncode != 0
 
+    def test_process_validate_rejects_semantic_errors(self, tmp_path):
+        """测试 --validate 能拦截运行前置配置错误"""
+        invalid_config = tmp_path / "semantic_invalid.yaml"
+        invalid_config.write_text(
+            """
+datasource:
+  type: mongodb
+  concurrency:
+    batch_size: 0
+columns_to_extract: []
+columns_to_write: {}
+prompt:
+  template: "{record_json}"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "cli.py",
+                "process",
+                "--config",
+                str(invalid_config),
+                "--validate",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+        assert result.returncode == 1
+        assert "Config invalid" in result.stdout
+        assert "datasource.type" in result.stdout
+        assert "batch_size" in result.stdout
+
+    def test_main_validate_rejects_semantic_errors(self, tmp_path):
+        """测试 main.py --validate 复用同一套语义校验"""
+        invalid_config = tmp_path / "main_semantic_invalid.yaml"
+        invalid_config.write_text(
+            """
+datasource:
+  type: mongodb
+columns_to_extract: []
+columns_to_write: {}
+prompt:
+  template: "{record_json}"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "main.py",
+                "--config",
+                str(invalid_config),
+                "--validate",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+        assert result.returncode == 1
+        assert "配置文件无效" in result.stdout
+        assert "datasource.type" in result.stdout
+
     def test_no_command(self):
         """测试无命令时显示帮助"""
         result = subprocess.run(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,7 @@
 
 import pytest
 from pathlib import Path
+import yaml
 
 
 class TestConfigLoading:
@@ -118,3 +119,133 @@ class TestConfigValidation:
 
         if "required_fields" in prompt:
             assert isinstance(prompt["required_fields"], list)
+
+
+class TestConfigSemanticValidation:
+    """配置语义校验测试"""
+
+    def test_validate_config_rejects_startup_blocking_errors(self, sample_config):
+        """测试 validate_config 能拦截启动阶段会失败的配置"""
+        from src.config import validate_config
+
+        sample_config["datasource"]["type"] = "mongodb"
+        sample_config["datasource"]["concurrency"]["batch_size"] = 0
+        sample_config["columns_to_extract"] = []
+
+        result = validate_config(sample_config)
+
+        assert any("datasource.type" in error for error in result["errors"])
+        assert any("batch_size" in error for error in result["errors"])
+        assert any("columns_to_extract" in error for error in result["errors"])
+
+    def test_validate_config_accepts_datasource_type_case_runtime_support(
+        self, sample_config
+    ):
+        """测试 datasource.type 大小写兼容 create_task_pool 的 lower 行为"""
+        from src.config import validate_config
+
+        sample_config["datasource"]["type"] = "Excel"
+
+        result = validate_config(sample_config)
+
+        assert not result["errors"]
+
+    def test_validate_config_rejects_prompt_without_template(self, sample_config):
+        """测试主配置缺少 prompt.template 时会被拦截"""
+        from src.config import validate_config
+
+        sample_config["prompt"] = {"system_prompt": "only system message"}
+
+        result = validate_config(sample_config)
+
+        assert any("prompt.template" in error for error in result["errors"])
+
+    def test_validate_config_warns_ignored_legacy_concurrency_keys(self, sample_config):
+        """测试已知会被忽略的旧并发配置键会给出 warning"""
+        from src.config import validate_config
+
+        sample_config["datasource"]["concurrency"]["max_workers"] = 8
+        sample_config["datasource"]["concurrency"]["retry_times"] = 5
+
+        result = validate_config(sample_config)
+
+        assert not result["errors"]
+        assert any("max_workers" in warning for warning in result["warnings"])
+        assert any("retry_times" in warning for warning in result["warnings"])
+
+    def test_validate_config_rejects_missing_routing_profile(
+        self, sample_config, tmp_path
+    ):
+        """测试 routing profile 缺失时 validate_config 不再误报有效"""
+        from src.config import validate_config
+
+        config_path = tmp_path / "config.yaml"
+        sample_config["routing"] = {
+            "enabled": True,
+            "field": "category",
+            "subtasks": [{"match": "a", "profile": "missing.yaml"}],
+        }
+
+        result = validate_config(sample_config, config_path)
+
+        assert any("profile 加载失败" in error for error in result["errors"])
+
+    def test_validate_config_rejects_non_bool_routing_enabled(self, sample_config):
+        """测试 routing.enabled 使用字符串时会被明确拦截"""
+        from src.config import validate_config
+
+        sample_config["routing"] = {"enabled": "false"}
+
+        result = validate_config(sample_config)
+
+        assert any("routing.enabled" in error for error in result["errors"])
+
+    def test_validate_config_allows_partial_routing_profile_prompt(
+        self, sample_config, tmp_path
+    ):
+        """测试 routing 子配置允许只覆盖 prompt 局部字段"""
+        from src.config import validate_config
+
+        profile_path = tmp_path / "rule.yaml"
+        profile_path.write_text(
+            yaml.safe_dump({"prompt": {"temperature": 0.1}}, allow_unicode=True),
+            encoding="utf-8",
+        )
+        config_path = tmp_path / "config.yaml"
+        sample_config["routing"] = {
+            "enabled": True,
+            "field": "category",
+            "subtasks": [{"match": "a", "profile": "rule.yaml"}],
+        }
+
+        result = validate_config(sample_config, config_path)
+
+        assert not result["errors"]
+
+    def test_validate_config_rejects_forbidden_routing_profile_keys(
+        self, sample_config, tmp_path
+    ):
+        """测试 routing 子配置包含非法顶层键时会失败"""
+        from src.config import validate_config
+
+        profile_path = tmp_path / "rule.yaml"
+        profile_path.write_text(
+            yaml.safe_dump(
+                {
+                    "prompt": {"template": "route: {record_json}"},
+                    "datasource": {"type": "sqlite"},
+                },
+                allow_unicode=True,
+            ),
+            encoding="utf-8",
+        )
+        config_path = tmp_path / "config.yaml"
+        sample_config["routing"] = {
+            "enabled": True,
+            "field": "category",
+            "subtasks": [{"match": "a", "profile": "rule.yaml"}],
+        }
+
+        result = validate_config(sample_config, config_path)
+
+        assert any("仅允许 prompt/validation" in error for error in result["errors"])

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -38,10 +38,10 @@ Control Server 测试
         test_kill_tree_nonexistent_process     验证清理不存在的进程不抛异常
 """
 
+import base64
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import base64
 
 
 class TestConfigAPI:
@@ -175,6 +175,35 @@ class TestControlServerAuth:
         app = auth_app.create_control_app()
         assert app is not None
         assert auth_app.get_control_auth_token() == "unit-test-token"
+
+    def test_config_validate_api_rejects_semantic_errors(self, auth_app):
+        """测试控制面板配置验证 API 会返回语义校验错误"""
+        from fastapi.testclient import TestClient
+
+        app = auth_app.create_control_app()
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/config/validate",
+            headers={"Authorization": "Bearer unit-test-token"},
+            json={
+                "path": "config.yaml",
+                "content": """
+datasource:
+  type: mongodb
+columns_to_extract: []
+columns_to_write: {}
+prompt:
+  template: "{record_json}"
+""".strip(),
+            },
+        )
+
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data["valid"] is False
+        assert "datasource.type" in "\n".join(data["errors"])
 
     def test_decode_base64url_token(self, auth_app):
         """测试 base64url token 解码"""

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -176,19 +176,20 @@ class TestControlServerAuth:
         assert app is not None
         assert auth_app.get_control_auth_token() == "unit-test-token"
 
-    def test_config_validate_api_rejects_semantic_errors(self, auth_app):
+    @pytest.mark.asyncio
+    async def test_config_validate_api_rejects_semantic_errors(self, auth_app):
         """测试控制面板配置验证 API 会返回语义校验错误"""
-        from fastapi.testclient import TestClient
-
         app = auth_app.create_control_app()
-        client = TestClient(app)
+        route = next(
+            route
+            for route in app.routes
+            if getattr(route, "path", None) == "/api/config/validate"
+        )
 
-        response = client.post(
-            "/api/config/validate",
-            headers={"Authorization": "Bearer unit-test-token"},
-            json={
-                "path": "config.yaml",
-                "content": """
+        data = await route.endpoint(
+            auth_app.ConfigValidateRequest(
+                path="config.yaml",
+                content="""
 datasource:
   type: mongodb
 columns_to_extract: []
@@ -196,12 +197,9 @@ columns_to_write: {}
 prompt:
   template: "{record_json}"
 """.strip(),
-            },
+            )
         )
 
-        data = response.json()
-
-        assert response.status_code == 200
         assert data["valid"] is False
         assert "datasource.type" in "\n".join(data["errors"])
 

--- a/tests/test_gateway_service.py
+++ b/tests/test_gateway_service.py
@@ -1,0 +1,211 @@
+"""
+Gateway 服务单元测试
+
+覆盖 src/gateway/service.py 中不依赖真实 HTTP 上游的核心行为。
+"""
+
+from pathlib import Path
+
+import yaml
+
+from src.gateway.schemas import ChatCompletionRequest
+from src.gateway.service import FluxApiService
+
+
+def _write_gateway_config(tmp_path: Path, models: list[dict]) -> Path:
+    config = {
+        "global": {"log": {"level": "error"}},
+        "gateway": {
+            "max_connections": 10,
+            "max_connections_per_host": 10,
+        },
+        "channels": {
+            "openai": {
+                "name": "openai",
+                "base_url": "https://api.example.test",
+                "api_path": "/v1/chat/completions",
+                "timeout": 60,
+                "proxy": "",
+                "ssl_verify": True,
+            }
+        },
+        "models": models,
+    }
+    path = tmp_path / "gateway.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return path
+
+
+def _model_config(
+    model_id: str,
+    *,
+    model: str | None = None,
+    weight: int = 1,
+    supports_json_schema: bool = True,
+    supports_advanced_params: bool = True,
+) -> dict:
+    return {
+        "id": model_id,
+        "name": model_id,
+        "model": model or model_id,
+        "channel_id": "openai",
+        "api_key": "test-key",
+        "timeout": 60,
+        "weight": weight,
+        "temperature": 0.3,
+        "safe_rps": 100,
+        "supports_json_schema": supports_json_schema,
+        "supports_advanced_params": supports_advanced_params,
+    }
+
+
+def _chat_request(**extra) -> ChatCompletionRequest:
+    payload = {
+        "model": "auto",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    payload.update(extra)
+    return ChatCompletionRequest(**payload)
+
+
+def test_build_upstream_payload_forwards_extra_openai_params(tmp_path):
+    """ChatCompletionRequest 允许的 extra 字段应透传到上游请求体"""
+    config_path = _write_gateway_config(tmp_path, [_model_config("model-a")])
+    service = FluxApiService(str(config_path))
+    model = service.models[0]
+    request = _chat_request(
+        response_format={"type": "json_object"},
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        tool_choice="auto",
+        seed=42,
+        parallel_tool_calls=False,
+        metadata={"trace_id": "unit-test", "empty": None},
+    )
+
+    payload = service._build_upstream_payload(model, request)
+
+    assert payload["model"] == "model-a"
+    assert payload["messages"] == [{"role": "user", "content": "hello", "name": None}]
+    assert payload["response_format"] == {"type": "json_object"}
+    assert payload["tools"][0]["function"]["name"] == "lookup"
+    assert payload["tool_choice"] == "auto"
+    assert payload["seed"] == 42
+    assert payload["parallel_tool_calls"] is False
+    assert payload["metadata"] == {"trace_id": "unit-test"}
+
+
+def test_build_upstream_payload_preserves_response_format_extra_fields(tmp_path):
+    """response_format=json_schema 的嵌套结构不应被 Pydantic 丢弃"""
+    config_path = _write_gateway_config(tmp_path, [_model_config("model-a")])
+    service = FluxApiService(str(config_path))
+    model = service.models[0]
+    request = _chat_request(
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer_schema",
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                },
+            },
+        }
+    )
+
+    payload = service._build_upstream_payload(model, request)
+
+    assert payload["response_format"]["type"] == "json_schema"
+    assert payload["response_format"]["json_schema"]["name"] == "answer_schema"
+    assert (
+        payload["response_format"]["json_schema"]["schema"]["properties"]["answer"][
+            "type"
+        ]
+        == "string"
+    )
+
+
+def test_get_available_model_filters_json_schema_capability(tmp_path):
+    """需要 JSON 输出时，不应选择未声明支持 JSON Schema 的模型"""
+    config_path = _write_gateway_config(
+        tmp_path,
+        [
+            _model_config("plain", weight=100, supports_json_schema=False),
+            _model_config("json", weight=1, supports_json_schema=True),
+        ],
+    )
+    service = FluxApiService(str(config_path))
+
+    selected = service.get_available_model(
+        requested_model_name="auto",
+        requires_json_schema=True,
+    )
+
+    assert selected is not None
+    assert selected.id == "json"
+
+
+def test_get_available_model_falls_back_when_requested_model_lacks_json_schema(
+    tmp_path,
+):
+    """指定模型不支持 JSON 输出时，应尝试其他符合能力的模型"""
+    config_path = _write_gateway_config(
+        tmp_path,
+        [
+            _model_config("plain", weight=100, supports_json_schema=False),
+            _model_config("json", weight=1, supports_json_schema=True),
+        ],
+    )
+    service = FluxApiService(str(config_path))
+
+    selected = service.get_available_model(
+        requested_model_name="plain",
+        requires_json_schema=True,
+    )
+
+    assert selected is not None
+    assert selected.id == "json"
+
+
+def test_get_available_model_returns_none_when_no_model_supports_json_schema(
+    tmp_path,
+):
+    config_path = _write_gateway_config(
+        tmp_path,
+        [_model_config("plain", supports_json_schema=False)],
+    )
+    service = FluxApiService(str(config_path))
+
+    selected = service.get_available_model(
+        requested_model_name="auto",
+        requires_json_schema=True,
+    )
+
+    assert selected is None
+
+
+def test_request_requires_json_schema_only_for_non_text_response_format(tmp_path):
+    config_path = _write_gateway_config(tmp_path, [_model_config("model-a")])
+    service = FluxApiService(str(config_path))
+
+    assert service._request_requires_json_schema(_chat_request()) is False
+    assert (
+        service._request_requires_json_schema(
+            _chat_request(response_format={"type": "text"})
+        )
+        is False
+    )
+    assert (
+        service._request_requires_json_schema(
+            _chat_request(response_format={"type": "json_object"})
+        )
+        is True
+    )

--- a/tests/test_gateway_service.py
+++ b/tests/test_gateway_service.py
@@ -133,6 +133,21 @@ def test_build_upstream_payload_preserves_response_format_extra_fields(tmp_path)
     )
 
 
+def test_build_upstream_payload_keeps_json_object_for_non_schema_model(tmp_path):
+    """json_object 是 JSON 模式，不应被 supports_json_schema=false 过滤掉"""
+    config_path = _write_gateway_config(
+        tmp_path,
+        [_model_config("model-a", supports_json_schema=False)],
+    )
+    service = FluxApiService(str(config_path))
+    model = service.models[0]
+    request = _chat_request(response_format={"type": "json_object"})
+
+    payload = service._build_upstream_payload(model, request)
+
+    assert payload["response_format"] == {"type": "json_object"}
+
+
 def test_get_available_model_filters_json_schema_capability(tmp_path):
     """需要 JSON 输出时，不应选择未声明支持 JSON Schema 的模型"""
     config_path = _write_gateway_config(
@@ -206,6 +221,12 @@ def test_request_requires_json_schema_only_for_non_text_response_format(tmp_path
     assert (
         service._request_requires_json_schema(
             _chat_request(response_format={"type": "json_object"})
+        )
+        is False
+    )
+    assert (
+        service._request_requires_json_schema(
+            _chat_request(response_format={"type": "json_schema"})
         )
         is True
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,6 +24,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 
 class TestExcelTaskPoolIntegration:
     """Excel 任务池集成测试"""

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -189,16 +189,20 @@ export async function saveConfig(path: string, content: string): Promise<ConfigW
 }
 
 /**
- * 校验 YAML 配置语法
- * 调用 POST /api/config/validate，服务端解析并验证 YAML 格式。
+ * 校验 YAML 配置语法和本地可验证的配置语义
+ * 调用 POST /api/config/validate，服务端解析 YAML 并执行配置校验。
  * @param content - 待验证的 YAML 字符串
+ * @param path - 配置文件路径，用于解析相对 routing profile
  * @returns 验证结果（是否合法 + 错误信息）
  */
-export async function validateConfig(content: string): Promise<ConfigValidateResponse> {
+export async function validateConfig(
+  content: string,
+  path: string = 'config.yaml'
+): Promise<ConfigValidateResponse> {
   const response = await fetch(`${API_BASE}/api/config/validate`, {
     method: 'POST',
     headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
-    body: JSON.stringify({ content }),
+    body: JSON.stringify({ path, content }),
   });
   if (!response.ok) {
     throw new Error(`Failed to validate config: ${response.status}`);

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -78,6 +78,9 @@ export interface Translations {
   enterYamlConfig: string;
   yamlSyntaxValid: string;
   yamlSyntaxError: string;
+  configValid: string;
+  configValidWithWarnings: string;
+  configInvalid: string;
   yamlNoTabs: string;
   failedToLoad: string;
   failedToSave: string;
@@ -321,6 +324,9 @@ const en: Translations = {
   enterYamlConfig: 'Enter YAML configuration...',
   yamlSyntaxValid: 'YAML syntax is valid',
   yamlSyntaxError: 'YAML syntax error',
+  configValid: 'Configuration is valid',
+  configValidWithWarnings: 'Configuration is valid with warnings',
+  configInvalid: 'Configuration is invalid',
   yamlNoTabs: 'YAML does not allow tabs. Please use spaces for indentation.',
   failedToLoad: 'Failed to load config',
   failedToSave: 'Failed to save config',
@@ -564,6 +570,9 @@ const zh: Translations = {
   enterYamlConfig: '输入 YAML 配置...',
   yamlSyntaxValid: 'YAML 语法有效',
   yamlSyntaxError: 'YAML 语法错误',
+  configValid: '配置有效',
+  configValidWithWarnings: '配置有效，但存在警告',
+  configInvalid: '配置无效',
   yamlNoTabs: 'YAML 不允许使用制表符。请使用空格缩进。',
   failedToLoad: '加载配置失败',
   failedToSave: '保存配置失败',

--- a/web/src/pages/ConfigEditor.tsx
+++ b/web/src/pages/ConfigEditor.tsx
@@ -305,12 +305,18 @@ export default function ConfigEditor({ configPath, onConfigPathChange, language 
     setError(null);
     setSuccess(null);
     try {
-      const result = await validateConfig(contentToValidate);
+      const result = await validateConfig(contentToValidate, configPath);
       if (result.valid) {
-        setSuccess(t.yamlSyntaxValid);
+        const warnings = result.warnings ?? [];
+        setSuccess(
+          warnings.length > 0
+            ? `${t.configValidWithWarnings}\n${warnings.join('\n')}`
+            : t.configValid
+        );
         setTimeout(() => setSuccess(null), 3000);
       } else {
-        setError(result.error ? `${t.yamlSyntaxError}: ${result.error}` : t.yamlSyntaxError);
+        const errors = result.errors?.length ? result.errors.join('\n') : result.error;
+        setError(errors ? `${t.configInvalid}:\n${errors}` : t.configInvalid);
       }
     } catch (err) {
       setError(`${t.failedToValidate}: ${err}`);
@@ -358,12 +364,12 @@ export default function ConfigEditor({ configPath, onConfigPathChange, language 
 
       {/* Messages */}
       {error && (
-        <div className="bg-red-50 text-red-600 px-4 py-3 rounded-lg mb-4 text-sm">
+        <div className="bg-red-50 text-red-600 px-4 py-3 rounded-lg mb-4 text-sm whitespace-pre-wrap">
           {error}
         </div>
       )}
       {success && (
-        <div className="bg-green-50 text-green-600 px-4 py-3 rounded-lg mb-4 text-sm">
+        <div className="bg-green-50 text-green-600 px-4 py-3 rounded-lg mb-4 text-sm whitespace-pre-wrap">
           {success}
         </div>
       )}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -97,10 +97,14 @@ export interface ConfigWriteResponse {
 
 /** 配置文件验证响应 */
 export interface ConfigValidateResponse {
-  /** YAML 语法是否合法 */
+  /** YAML 语法和本地可验证的配置语义是否合法 */
   valid: boolean;
   /** 验证错误信息（仅在 valid=false 时存在） */
   error?: string;
+  /** 配置错误列表 */
+  errors?: string[];
+  /** 配置警告列表 */
+  warnings?: string[];
 }
 
 /** 顶部导航标签页类型：仪表盘 / 配置 / 监控 */


### PR DESCRIPTION
## Summary
- Improve AI response JSON extraction by scanning balanced JSON objects instead of relying on non-greedy object matching.
- Keep scanning after an invalid JSON candidate, including invalid Markdown JSON code blocks, so a later valid result can still be used.
- Replace regex-only trailing comma cleanup with a string-aware scanner to avoid corrupting literal `,}` or `,]` text inside JSON strings.
- Preserve and forward OpenAI-compatible extra chat completion parameters, including nested response_format fields such as json_schema.
- Respect model supports_json_schema capability only for strict `json_schema` requests; keep `json_object` passthrough compatible with non-schema models.
- Add shared semantic config validation for `process --validate`, `main.py --validate`, and the control-panel config validator.
- Reject startup-blocking config issues such as unsupported datasource types, missing datasource sections, empty input/output columns, missing `prompt.template`, invalid routing profiles, and non-boolean routing toggles.
- Surface warnings for ignored legacy concurrency keys such as `max_workers`, `retry_times`, and `backoff_factor` without rejecting otherwise valid configs.
- Add focused gateway, content processor, config validation, CLI, control-panel, unit, and integration tests for the covered edge cases.
- Mark integration tests correctly and run the Integration Tests job in GitHub Actions on PR/push/workflow_dispatch.
- Update GUI/config/test documentation so validation and CI behavior match the current code.
- Migrate gateway Pydantic models from class Config to ConfigDict.

## Validation
- python -m pytest
- python -m pytest tests/ -m "integration" --tb=short
- python -m pytest tests/ -m "not integration" --tb=short
- black --check src/ tests/ cli.py main.py gateway.py
- ruff check src/ tests/ cli.py main.py gateway.py
- npm run lint
- npm run build
- python cli.py process --config config.yaml --validate
- python main.py --config config.yaml --validate
