### PR TITLE
docs: organize Codex AGENTS.md instructions

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,29 @@
+# .github navigation card
+
+GitHub Actions workflows and CI helper scripts. Read this card before modifying workflow triggers, lint/test matrices, packaging jobs, release behavior, dependency checks, or CI scripts.
+Key files: `workflows/test.yml`, `workflows/build-pyinstaller.yml`, `workflows/build-nuitka.yml`, `scripts/check_deps.py`.
+
+## Why this is high-risk
+
+- Build workflows create release artifacts and GitHub Releases on `v*` tags.
+- Test workflow covers multiple Python versions and OS/architecture combinations.
+- Packaging jobs depend on frontend build output, Python dependencies, compilers, and platform-specific commands.
+
+## Local invariants
+
+- `test.yml` quality checks are `ruff`, `black --check`, permissive `mypy`, syntax compile, unit matrix, CLI tests, performance library checks, and integration tests.
+- Build workflows run `cd web && npm ci && npm run build` before full GUI packaging.
+- PyInstaller has full and CLI-only variants; Nuitka builds full GUI bundles.
+- Python and Node versions in workflow `env` are part of the release surface. Keep docs and build assumptions aligned when changing them.
+- Optional dependencies may be allowed to fail during install in unit-test matrix jobs, but critical runtime checks should remain explicit.
+
+## Do not
+
+- Do not add plain-text secrets, tokens, or credentials to workflow files.
+- Do not remove branches, paths, platforms, or release conditions without calling out the compatibility impact.
+- Do not trigger releases, upload artifacts, or push tags unless the user explicitly asks.
+
+## Validation
+
+- `python -m py_compile .github/scripts/check_deps.py`
+- There is no local GitHub Actions runner configured by default. For workflow syntax, inspect YAML carefully or use external validation only when available.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,156 @@
+# AI-DataFlux repository agent instructions
+
+## Purpose
+
+AI-DataFlux is a Python 3.10+ batch AI processing engine with an OpenAI-compatible gateway, multiple datasource task pools, and a React/Vite local control panel.
+
+## Codex startup behavior
+
+- Codex is normally started from the repository root. This file is the startup router for the whole repository.
+- Subdirectory `AGENTS.md` files are local navigation cards. They are not always loaded automatically when Codex starts at the root.
+- Before editing files under any directory marked `Yes` in the `Local AGENTS.md` column, read that local file first with `cat <path>/AGENTS.md`.
+- If more than one nested `AGENTS.md` applies, read them from shallow to deep before editing. For example, changes under `src/data/feishu/` require `src/data/AGENTS.md` and then `src/data/feishu/AGENTS.md`.
+- If Codex is started from a subdirectory, local cards may be loaded by the path chain, but this root file remains the router for root-start workflows.
+
+## Directory map
+
+| Path | Responsibility | Local AGENTS.md | Read when |
+|---|---|---:|---|
+| `cli.py` | Unified CLI for `process`, `gateway`, `gui`, `token`, `check`, and `version`. | No | Root rules are enough; inspect this file before adding CLI commands. |
+| `main.py` | Direct processing entry point that delegates to `src.core.processor`. | No | When changing process startup behavior. |
+| `gateway.py` | Direct gateway entry point that delegates to `src.gateway.app`. | No | When changing standalone gateway startup. |
+| `src/config/` | YAML loading, defaults, semantic validation, and logging setup. | No | When changing config schema; also check `web/`, `docs/`, and tests. |
+| `src/core/` | Core processing pipeline: coordinator, scheduler, content parsing, retry, state, token estimation, and API client. | Yes | Before changing processing flow, routing, retry decisions, progress reporting, or token estimation. |
+| `src/data/` | Datasource task pools, factory, file/DB/Feishu integrations, and DataFrame engine abstraction. | Yes | Before changing task pool contracts, datasource behavior, writeback semantics, or adding a datasource. |
+| `src/data/engines/` | Pandas/Polars `BaseEngine` implementations and optional library detection. | Yes | Before changing DataFrame operations, engine selection, reader/writer fallback, or vectorized filtering. |
+| `src/data/feishu/` | Native aiohttp Feishu client plus Bitable/Sheet task pools. | Yes | Before changing Feishu auth, rate limits, pagination, chunking, snapshots, or writeback. |
+| `src/gateway/` | FastAPI OpenAI-compatible gateway, model dispatch, rate limiting, session pool, DNS resolver, schemas. | Yes | Before changing `/v1/*`, `/admin/*`, model routing, streaming, limiter, or upstream HTTP behavior. |
+| `src/control/` | FastAPI control server for GUI, config file API, process management, auth, status, and log WebSockets. | Yes | Before changing GUI backend APIs, process lifecycle, config read/write, auth, static serving, or logs. |
+| `src/models/` | Shared dataclasses and error enums. | No | Follow the closest caller card, usually `src/core/` or `src/gateway/`. |
+| `src/utils/` | Console/output helpers. | No | Root rules are enough. |
+| `web/` | React 19 + TypeScript + Vite control panel. | Yes | Before changing frontend API calls, config editor, dashboard, logs, i18n, or build settings. |
+| `web/dist/` | Generated frontend build output served by `src/control/`. | No | Do not edit manually; regenerate with `cd web && npm run build`. |
+| `tests/` | Pytest suite, fixtures, markers, unit/integration coverage. | Yes | Before changing shared fixtures, test conventions, markers, or broad test behavior. |
+| `docs/` | Chinese architecture, config, datasource, GUI, routing, and build docs. | Yes | Before changing docs or when code changes affect documented config/API/CLI behavior. |
+| `.github/` | GitHub Actions workflows and CI helper scripts. | Yes | Before changing CI, packaging, release, platform matrix, or dependency checks. |
+| `legacy/` | Historical reference implementations. | Yes | Before using legacy code as migration input; do not edit casually. |
+| `.config/rules/` | Local routing profile examples/configs, ignored by git. | No | Read only when a routing task references local profiles. |
+| `.examples/`, `local/`, `.codex/`, `.claude/` | Local examples, reports, and agent/runtime material. | No | Treat as local context unless the user explicitly asks. |
+| `config-example.yaml` | Public configuration template. | No | Update together with config schema changes. |
+| `config.yaml` | Local ignored runtime configuration. | No | May contain test credentials; use only when user asks or when local validation needs it. |
+
+## On-demand cat protocol
+
+Before editing files under a directory that has a local `AGENTS.md`, run:
+
+```bash
+cat <path>/AGENTS.md
+```
+
+For nested cards, read them in order. Example:
+
+```bash
+cat src/data/AGENTS.md
+cat src/data/feishu/AGENTS.md
+```
+
+Use the local card for directory-specific invariants. If a local card conflicts with this root file, the local card wins for that subtree.
+
+## Commands
+
+| Command | Purpose | Scope | Sandbox notes |
+|---|---|---|---|
+| `python -m pip install -r requirements-core.txt` | Install core runtime dependencies. | Python | Needs network unless packages are cached. |
+| `python -m pip install -r requirements-optional.txt` | Install optional gateway/performance/token dependencies. | Python | Needs network; some optional wheels may be unavailable on specific platforms. |
+| `python -m pip install -r requirements.txt` | Install full runtime dependency set. | Python | Needs network unless cached. |
+| `python cli.py check` | Check available runtime and optional libraries. | Python | Requires installed dependencies; no external service expected. |
+| `python cli.py version` | Print CLI version. | Python | Local. |
+| `python cli.py process --config config-example.yaml --validate` | Validate example config without running jobs. | Python | Local; uses only local semantic validation. |
+| `python cli.py process --config config.yaml --validate` | Validate local config. | Python | Uses ignored local config; may contain test credentials. |
+| `python cli.py process --config config.yaml` | Run processing. | Python | Requires configured datasource and gateway/API availability. |
+| `python cli.py gateway --port 8787` | Start OpenAI-compatible gateway. | Python | Long-running service; requires valid model/channel config for real traffic. |
+| `python gateway.py --config config.yaml --port 8787` | Start gateway through standalone entry point. | Python | Long-running service; same external config constraints as gateway CLI. |
+| `DATAFLUX_CONTROL_TOKEN=test-token python cli.py gui --no-browser` | Start local control panel with fixed auth token. | Python/control | Long-running service on local port; requires `web/dist/` for built frontend serving. |
+| `python cli.py token --config config.yaml` | Estimate input/output token usage. | Python | Requires datasource access and `tiktoken` for full token estimation. |
+| `pytest tests/ -v -m "not integration"` | Main non-integration pytest suite. | Tests | Requires test dependencies; should not require external DB/API. |
+| `pytest tests/ -v -m integration` | Integration-marked tests. | Tests | CI describes current integration tests as local temp-file/data tests; still heavier than unit tests. |
+| `pytest tests/ --cov=src --cov-report=term-missing` | Coverage report. | Tests | Requires `pytest-cov`; `.coveragerc` omits `src/gateway/*`. |
+| `ruff check src/ tests/ cli.py main.py gateway.py` | Python lint check used by repository guidelines. | Python | Requires `ruff`. |
+| `black --check src/ tests/ cli.py main.py gateway.py` | Python format check used by repository guidelines. | Python | Requires `black`; CI pins `black==25.11.0`. |
+| `mypy src/ --ignore-missing-imports` | CI type check. | Python | CI allows this to fail with `|| true`; do not treat as the only gate. |
+| `python -m py_compile cli.py main.py gateway.py` | Syntax check root entry points. | Python | Local. |
+| `find src -name "*.py" -exec python -m py_compile {} \;` | Syntax check package modules. | Python | Local. |
+| `cd web && npm ci` | Install frontend dependencies from `package-lock.json`. | Web | Needs network unless npm cache is warm. |
+| `cd web && npm run build` | TypeScript build plus Vite production build. | Web | Requires installed npm deps; writes `web/dist/`. |
+| `cd web && npm run lint` | ESLint check. | Web | Requires installed npm deps. |
+| `cd web && npm run dev` | Start Vite dev server. | Web | Long-running local service. |
+| `cd web && npm run preview` | Preview built frontend. | Web | Long-running local service; requires `web/dist/`. |
+
+CI-specific packaging commands in `.github/workflows/build-*.yml` use PyInstaller/Nuitka, compilers, GitHub release actions, and sometimes platform setup steps. Do not treat those as default local validation.
+
+## Global rules
+
+- Default communication with the user is Chinese. Keep code, commands, file paths, API names, and config keys in English.
+- Python targets 3.10+. Use 4-space indentation, `snake_case` for functions/modules, and `PascalCase` for classes.
+- Follow existing module boundaries. Prefer extending `src/core/`, `src/data/`, `src/gateway/`, `src/control/`, and `web/` through their existing factories, components, and helper APIs.
+- Preserve optional dependency behavior. Imports for optional libraries must stay guarded or lazy so missing `polars`, `fastexcel`, `xlsxwriter`, `aiohttp`, `psutil`, `mysql-connector-python`, `psycopg2`, or `tiktoken` degrades as designed.
+- Config schema changes are cross-cutting. Check `src/config/settings.py`, `config-example.yaml`, `docs/CONFIG.md`, relevant `web/src/components/config/sections/*`, `web/src/types.ts`, and tests before claiming completion.
+- CLI surface changes require `cli.py`, help tests in `tests/test_cli.py`, and docs/examples to stay aligned.
+- Datasource behavior must preserve `BaseTaskPool` contracts: shard boundaries, `get_task_batch`, `reload_task_data`, `update_task_results`, `close`, and token estimation sampling hooks.
+- DataFrame engine behavior must go through `BaseEngine` where possible; avoid direct pandas/polars calls in higher-level datasource code when an engine method already exists.
+- Gateway request/response changes must preserve OpenAI Chat Completions compatibility unless the user explicitly asks to break it.
+- Control server changes must preserve local-only serving defaults, token auth for `/api/*` and `/api/logs`, YAML-only config read/write, and project-root path containment.
+- Frontend changes should reuse existing shared controls in `web/src/components/config/shared/` and keep TypeScript API types aligned with backend responses.
+- Tests should be focused near the changed behavior. Prefer existing fixtures in `tests/conftest.py`; use mocks/temp files for external APIs and databases unless an integration task explicitly asks for real services.
+- Generated or build output is not source. Regenerate `web/dist/` with the frontend build instead of hand-editing it.
+
+## Do not
+
+- Do not modify `AGENTS.override.md` or create one unless the user explicitly requests that strategy.
+- Do not commit or print local secrets from `config.yaml`, `.env`, datasource credentials, model API keys, or Feishu tokens. It is acceptable to use local test credentials when the user asks for local validation.
+- Do not hand-edit `web/dist/`, `__pycache__/`, `.pytest_cache/`, `.ruff_cache/`, coverage artifacts, `node_modules/`, or packaging output.
+- Do not replace the existing architecture with a new framework when an established local module already covers the need.
+- Do not run publishing/release operations, upload artifacts, or create GitHub releases unless explicitly requested.
+- Do not silently remove platform support from CI matrices or packaging workflows.
+- Do not make tests depend on real external AI providers, Feishu, MySQL, PostgreSQL, or local ports unless the test is explicitly marked and documented for that dependency.
+
+## Validation
+
+For a typical Python-only change:
+
+1. Run a targeted pytest command for the changed module.
+2. Run `pytest tests/ -v -m "not integration"` when the blast radius is broader.
+3. Run `ruff check src/ tests/ cli.py main.py gateway.py`.
+4. Run `black --check src/ tests/ cli.py main.py gateway.py`.
+
+For frontend changes:
+
+1. Run `cd web && npm run lint`.
+2. Run `cd web && npm run build`.
+3. If behavior changed in the GUI, validate through the control server or browser workflow when practical.
+
+For config/schema changes:
+
+1. Run `python cli.py process --config config-example.yaml --validate`.
+2. Run related config tests, usually `pytest tests/test_config.py -v`.
+3. Check backend, frontend, docs, and example config for the same field names and defaults.
+
+For gateway changes:
+
+1. Run `pytest tests/test_gateway_service.py -v`.
+2. Run `python cli.py gateway --help`.
+3. Start the gateway only when a valid config and port are available; report if full upstream validation was skipped.
+
+For control server changes:
+
+1. Run `pytest tests/test_control.py -v`.
+2. For manual smoke testing, use `DATAFLUX_CONTROL_TOKEN=test-token python cli.py gui --no-browser`.
+3. If testing actual GUI pages, ensure `web/dist/` exists or rebuild it.
+
+If a validation command cannot run because dependencies, network, credentials, ports, or external services are unavailable, say exactly what was skipped and why.
+
+## Notes for future agents
+
+- `CLAUDE.md` contains useful historical architecture notes, but `AGENTS.md` is the Codex project instruction surface. Keep future Codex-specific guidance here.
+- `AGENTS.md` is ignored by this repository's `.gitignore`, so normal `git diff` may not show these instruction files unless they are force-added or compared manually.
+- The project has Chinese docs and many Chinese comments. Keep new agent guidance in Chinese unless there is a strong local reason to use English.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,26 @@
+# docs navigation card
+
+Chinese documentation for architecture, configuration, datasources, Feishu, GUI, routing, and build variants. Read this card before changing docs or when code changes alter documented commands, config fields, APIs, or behavior.
+Key files: `ARCH.md`, `CONFIG.md`, `DATA_SOURCE.md`, `FEISHU.md`, `GUI.md`, `ROUTING.md`, `BUILD_VARIANTS.md`, `README.md`.
+
+## Local invariants
+
+- Documentation should be derived from current code and config, not guessed. Check source files before documenting behavior.
+- Keep command examples aligned with actual CLI and `web/package.json` scripts.
+- Config docs must stay aligned with `src/config/settings.py`, `config-example.yaml`, frontend config sections, and `tests/test_config.py`.
+- API/control docs must stay aligned with `src/control/server.py`, `src/control/config_api.py`, `src/control/process_manager.py`, and `web/src/api.ts`.
+- Gateway docs must preserve OpenAI compatibility details unless code intentionally changes them.
+- Use placeholders for credentials and tokens. Do not paste real local `config.yaml` secrets into docs.
+- Historical performance or coverage numbers should be labeled as examples unless they were freshly measured.
+
+## Local rules
+
+- Prefer Chinese prose to match the existing docs.
+- Keep diagrams and file maps compact; update only the affected sections.
+- If docs mention a command as validation, ensure it exists in the repository config or CLI.
+
+## Validation
+
+- No docs build command is configured.
+- For docs-only changes, review rendered Markdown when practical.
+- For docs tied to code behavior, run the relevant code/test validation from the root `AGENTS.md`.

--- a/legacy/AGENTS.md
+++ b/legacy/AGENTS.md
@@ -1,0 +1,20 @@
+# legacy navigation card
+
+Historical reference implementations for AI-DataFlux. Read this card before using files here as migration input or comparing old behavior to current `src/` modules.
+Key files: `AI-DataFlux.py`, `Flux-Api.py`, `Flux_Data.py`.
+
+## Why this is guarded
+
+- `legacy/` is reference code, not the active runtime path.
+- Copying behavior from here can reintroduce old architecture, duplicated logic, or outdated config semantics.
+
+## Local rules
+
+- Do not edit legacy files unless the user explicitly requests a legacy migration or archival cleanup.
+- When porting behavior, implement it in the active modules under `src/` and add tests there.
+- Treat legacy code as evidence to compare against current behavior, not as an import target.
+
+## Validation
+
+- Use the validation command for the active module that receives the migrated behavior.
+- If only reading legacy code, no validation command is required.

--- a/src/control/AGENTS.md
+++ b/src/control/AGENTS.md
@@ -1,0 +1,32 @@
+# src/control navigation card
+
+FastAPI backend for the local control panel. Read this before changing control APIs, auth, config read/write, process management, status polling, log WebSockets, or static serving.
+Key files: `server.py`, `config_api.py`, `process_manager.py`, `runtime.py`.
+
+## Why this is high-risk
+
+- The control server can start and stop subprocesses and write YAML config files.
+- It exposes local HTTP and WebSocket endpoints consumed by the React app.
+- Path validation and token auth are the main guardrails.
+
+## Local invariants
+
+- `/api/*` and `/api/logs` must require the control token. Token sources are `DATAFLUX_CONTROL_TOKEN` or a generated token, compared with `secrets.compare_digest`.
+- Browser WebSocket auth uses `Sec-WebSocket-Protocol` with `dataflux-token-b64.<base64url>`. Keep frontend and backend in sync.
+- Config read/write is limited to `.yaml` and `.yml` inside `PROJECT_ROOT`; preserve realpath/commonpath containment checks.
+- Config writes must remain backup + atomic replace operations.
+- `ProcessManager` manages `gateway` and `process` states as `stopped`, `running`, or `exited`; stop operations must terminate child process trees where possible.
+- Progress file handling must tolerate stale or missing files and avoid blocking the event loop during status polling.
+- Static serving depends on `web/dist/`; root detection lives in `runtime.py`.
+
+## Do not
+
+- Do not broaden config file access to arbitrary file types without explicit user approval.
+- Do not remove auth checks for convenience tests; tests should provide a token.
+- Do not block the FastAPI event loop with long synchronous probes when an async/cache path exists.
+
+## Validation
+
+- `pytest tests/test_control.py -v`
+- `DATAFLUX_CONTROL_TOKEN=test-token python cli.py gui --no-browser` for manual smoke testing.
+- Rebuild frontend with `cd web && npm run build` if static asset behavior changed.

--- a/src/core/AGENTS.md
+++ b/src/core/AGENTS.md
@@ -1,0 +1,25 @@
+# src/core navigation card
+
+Core processing pipeline for AI-DataFlux. Read this before modifying `processor.py`, `scheduler.py`, `validator.py`, `token_estimator.py`, or `clients/`, `content/`, `retry/`, and `state/`.
+Key files: `src/core/processor.py`, `src/core/scheduler.py`, `src/core/content/processor.py`, `src/core/retry/strategy.py`, `src/core/state/manager.py`, `src/core/clients/flux_client.py`.
+
+## Local invariants
+
+- `UniversalAIProcessor` is the coordinator. Keep data access in `src/data/`, API calls in `FluxAIClient`, parsing in `ContentProcessor`, retry decisions in `RetryStrategy`, and metadata in `TaskStateManager`.
+- Preserve continuous task flow: maintain active concurrency, process completed tasks with `asyncio.wait(... FIRST_COMPLETED)`, and avoid reverting to "wait for whole batch then write" behavior.
+- Error semantics are contractual: `API_ERROR` pauses and reloads data; `CONTENT_ERROR` retries without reload; `SYSTEM_ERROR` reloads without global pause.
+- `TaskMetadata` must stay separate from business row data. Do not store retry counters or error history inside datasource records.
+- Routing profiles may only override `prompt` and `validation`. Implicit routing fields are used for routing but excluded from prompt payloads.
+- Progress JSON must be atomic, refreshed during long runs, and removed on normal completion.
+
+## Local rules
+
+- Add or update focused tests under `tests/core/` or the matching top-level `tests/test_*.py` file when changing component behavior.
+- Keep `token_estimator.py` tolerant of missing `tiktoken` until estimation is actually requested.
+- Do not let core modules import frontend/control concerns. The processing engine should remain usable from CLI and tests without the GUI.
+
+## Validation
+
+- `pytest tests/core/ tests/test_scheduler.py tests/test_validator.py tests/test_token_estimator.py -v`
+- `pytest tests/test_integration.py -v` for end-to-end flow changes.
+- Use root validation commands for broader changes.

--- a/src/data/AGENTS.md
+++ b/src/data/AGENTS.md
@@ -1,0 +1,26 @@
+# src/data navigation card
+
+Datasource layer for file, database, and Feishu task pools. Read this before changing `base.py`, `factory.py`, `excel.py`, `mysql.py`, `postgresql.py`, `sqlite.py`, or nested datasource modules.
+Key files: `src/data/base.py`, `src/data/factory.py`, `src/data/excel.py`, `src/data/mysql.py`, `src/data/postgresql.py`, `src/data/sqlite.py`.
+
+## Local invariants
+
+- Every datasource must satisfy `BaseTaskPool`: counts, ID boundaries, shard loading, batch pop, writeback, reload, sampling hooks, and `close()`.
+- `columns_to_extract` names input fields. `columns_to_write` maps output aliases to actual datasource columns; AI result dictionaries use aliases.
+- Unprocessed/processed semantics must stay consistent across datasources: input validity respects `require_all_input_fields`; processed rows have all output columns non-empty.
+- `create_task_pool()` is the datasource factory. Adding a datasource requires implementation, guarded dependency detection if needed, factory wiring, docs/config updates, and tests.
+- Optional DB and file dependencies must remain optional. Missing MySQL/PostgreSQL/Excel/performance libraries should fail with clear errors only when that datasource or feature is selected.
+- File datasources should use `src/data/engines/` abstractions instead of bypassing them with direct pandas/polars code.
+- Database writeback must preserve transactions, parameterized values, and identifier validation.
+
+## Local rules
+
+- If editing `src/data/engines/`, also read `src/data/engines/AGENTS.md`.
+- If editing `src/data/feishu/`, also read `src/data/feishu/AGENTS.md`.
+- Tests should use temp files, mocks, or isolated local databases, not real external MySQL/PostgreSQL/Feishu services.
+
+## Validation
+
+- `pytest tests/test_factory.py tests/test_csv_pool.py tests/test_sqlite_pool.py tests/test_postgresql_pool.py -v`
+- `pytest tests/test_engines.py -v` when file/engine behavior changes.
+- `pytest tests/test_feishu_client_async.py tests/test_feishu_pool.py -v` when Feishu behavior changes.

--- a/src/data/engines/AGENTS.md
+++ b/src/data/engines/AGENTS.md
@@ -1,0 +1,23 @@
+# src/data/engines navigation card
+
+DataFrame engine abstraction for Pandas and Polars. Read this card before changing `BaseEngine`, `PandasEngine`, `PolarsEngine`, engine selection, optional library detection, or vectorized filtering.
+Key files: `base.py`, `__init__.py`, `pandas_engine.py`, `polars_engine.py`.
+
+## Local invariants
+
+- `BaseEngine` is the public contract. Higher layers depend on its method names and return semantics, not on pandas/polars-specific APIs.
+- Pandas and Polars implementations should preserve equivalent behavior for row IDs, column names, empty values, string conversion, slicing, batch updates, and CSV/Excel I/O.
+- `engine: auto` prefers Polars when usable and falls back to Pandas. `excel_reader: auto` prefers calamine/fastexcel, and `excel_writer: auto` prefers xlsxwriter.
+- Optional library checks intentionally run in subprocesses to avoid crashing the main process on incompatible platforms. Do not replace this with direct top-level imports.
+- Methods that mutate data should keep the established return convention. If an engine returns a new DataFrame, callers must receive and use it.
+
+## Local rules
+
+- Add parity tests when changing any `BaseEngine` method.
+- Keep performance paths vectorized where the existing API already has vectorized operations.
+- Do not introduce a new engine without updating `__init__.py`, availability detection, docs/config references, and tests.
+
+## Validation
+
+- `pytest tests/test_engines.py tests/test_integration.py -v`
+- `python cli.py check` after dependency or availability-detection changes.

--- a/src/data/feishu/AGENTS.md
+++ b/src/data/feishu/AGENTS.md
@@ -1,0 +1,30 @@
+# src/data/feishu navigation card
+
+Native Feishu integration using aiohttp, without the official SDK. Read this card before modifying auth, request retry, Bitable/Sheet snapshots, pagination, chunking, or writeback.
+Key files: `client.py`, `bitable.py`, `sheet.py`, `__init__.py`.
+
+## Why this is high-risk
+
+- Code here talks to external Feishu APIs and can update user spreadsheets or Bitable records.
+- Auth tokens, app secrets, app tokens, table IDs, and spreadsheet tokens are sensitive even when local test credentials are used.
+- Feishu rate limits and oversized range errors require careful retry/chunking behavior.
+
+## Local invariants
+
+- `FeishuClient` owns tenant token refresh, aiohttp session lifecycle, retry/backoff, QPS limiting, and concurrency limiting.
+- A `ClientSession` is tied to its event loop. Preserve the existing event-loop switch detection and session rebuild behavior.
+- 429, `Retry-After`, 5xx, network errors, token invalidation, Feishu business rate limits, and too-large errors must keep their distinct handling paths.
+- Bitable uses integer `task_id` values mapped to string `record_id` values through stable snapshot maps.
+- Sheet uses 0-based data row task IDs; actual spreadsheet row numbers account for the header row.
+- Sheet writes are serialized by design. Do not parallelize writes for one document unless the API behavior is revalidated.
+
+## Do not
+
+- Do not add new logs that expose `app_secret`, tenant access tokens, bearer headers, or full credential payloads.
+- Do not require real Feishu network calls in default tests.
+- Do not replace split/chunk logic with recursion that can overflow or lose partial progress on large ranges.
+
+## Validation
+
+- `pytest tests/test_feishu_client_async.py tests/test_feishu_pool.py -v`
+- For real API smoke tests, explicitly state that Feishu credentials and network access are required.

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -1,0 +1,26 @@
+# src/gateway navigation card
+
+OpenAI-compatible FastAPI gateway for model dispatch, failover, rate limiting, session reuse, and admin health/model endpoints. Read this card before changing gateway routes, schemas, upstream request handling, streaming, dispatch, limiter, resolver, or session pooling.
+Key files: `app.py`, `service.py`, `schemas.py`, `dispatcher.py`, `limiter.py`, `session.py`, `resolver.py`.
+
+## Local invariants
+
+- Preserve OpenAI Chat Completions compatibility for `/v1/chat/completions`, `/v1/models`, and request/response shapes unless the user explicitly asks for a breaking change.
+- `ChatCompletionRequest` allows extra fields for forward compatibility. Do not drop unknown OpenAI-style fields unless they are intentionally unsupported and tested.
+- Model name resolution maps configured `id`, `model`, and `name` aliases to internal IDs. Keep this compatible with existing configs.
+- Dispatch must consider availability, model weight, rate limits, and exclusion of failed models during retry/failover.
+- `chat_completion()` may retry another model when an upstream call fails, but should not loop indefinitely. Preserve the existing bounded retry behavior.
+- Streaming responses must keep Server-Sent Events framing and `[DONE]` handling intact.
+- `SessionPool` owns aiohttp connector/session reuse. Ensure startup/shutdown paths close async resources.
+
+## Local rules
+
+- Any public schema or endpoint change needs tests in `tests/test_gateway_service.py` or new focused tests.
+- Keep proxy, `ssl_verify`, and optional IP-pool behavior wired through channel/model config.
+- Do not let gateway code depend on `src/control/` or the React app.
+
+## Validation
+
+- `pytest tests/test_gateway_service.py -v`
+- `python cli.py gateway --help`
+- Starting a live gateway requires a valid config with models/channels and a free port.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,25 @@
+# tests navigation card
+
+Pytest suite for CLI, config, core components, datasources, gateway, control server, and integration behavior. Read this card before changing shared fixtures, markers, test layout, or broad test patterns.
+Key files: `pytest.ini`, `tests/conftest.py`, `tests/README.md`, `tests/test_*.py`, `tests/core/`.
+
+## Local invariants
+
+- Test discovery follows `pytest.ini`: files `test_*.py`, classes `Test*`, functions `test_*`.
+- Shared fixtures belong in `tests/conftest.py`; keep temporary files under pytest-provided temp paths.
+- Use markers consistently: `integration` for integration tests and `slow` for expensive tests.
+- Default tests should not require live AI APIs, Feishu, MySQL, PostgreSQL, or persistent local services. Mock external HTTP/API behavior unless an integration task explicitly asks otherwise.
+- Optional dependency behavior is part of test coverage. Tests should verify fallback/skip behavior instead of assuming every optional library is installed.
+- Component tests under `tests/core/` should stay focused on isolated logic.
+
+## Local rules
+
+- When fixing a bug, add or update the smallest regression test that fails without the fix.
+- Keep test names behavior-oriented enough to diagnose failures from CI logs.
+- Avoid asserting on brittle full log strings when stable fields or substrings are enough.
+
+## Validation
+
+- `pytest tests/ -v -m "not integration"`
+- `pytest tests/ -v -m integration`
+- `pytest tests/ --cov=src --cov-report=term-missing`

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,26 @@
+# web navigation card
+
+React 19 + TypeScript + Vite control panel for AI-DataFlux. Read this card before changing frontend API calls, dashboard controls, config editor sections, log streaming, i18n, build config, or generated `dist` handling.
+Key files: `src/api.ts`, `src/types.ts`, `src/App.tsx`, `src/pages/`, `src/components/config/`, `vite.config.ts`, `package.json`.
+
+## Local invariants
+
+- Package manager is npm, backed by `package-lock.json`. Use `npm ci` for clean installs.
+- API calls use relative URLs so the app works when served by `src/control/server.py` from the same origin.
+- Control token handling lives in `src/api.ts`: URL `#token=...` is persisted to `sessionStorage`, removed from the address bar, and sent as Bearer auth.
+- Log WebSockets pass auth through `Sec-WebSocket-Protocol` using the `dataflux-token-b64.<base64url>` format. Keep this aligned with `src/control/server.py`.
+- `src/types.ts` mirrors backend API responses. Update it with backend schema changes.
+- Config editor sections must write YAML paths that backend validation and `config-example.yaml` understand.
+- Reuse controls in `src/components/config/shared/` for form fields, toggles, number inputs, lists, cards, and selects.
+
+## Do not
+
+- Do not hardcode `localhost` or an absolute backend URL into API helpers.
+- Do not hand-edit `web/dist/`; regenerate it with `npm run build`.
+- Do not introduce new config keys only in the frontend. Backend validation, docs, examples, and tests must be updated too.
+
+## Validation
+
+- `cd web && npm run lint`
+- `cd web && npm run build`
+- For API contract changes, also run relevant backend tests, usually `pytest tests/test_control.py tests/test_config.py -v`.


### PR DESCRIPTION
## Summary

- Add a root `AGENTS.md` router with Codex startup behavior, directory map, on-demand local-card loading protocol, command index, global rules, and validation guidance.
- Add local `AGENTS.md` navigation cards for high-value subtrees: `src/core/`, `src/data/`, `src/data/engines/`, `src/data/feishu/`, `src/gateway/`, `src/control/`, `web/`, `tests/`, `docs/`, `.github/`, and `legacy/`.
- Keep the change scoped to agent instructions only; no source, tests, workflows, generated assets, or dependency files changed.

## Validation

- `git diff --cached --check` before commit
- Reviewed staged file list and diff stat before commit
- Confirmed no `AGENTS.override.md` exists
- Confirmed ordinary worktree had no untracked docs/code files before branching

## Notes

`AGENTS.md` is ignored by `.gitignore`, so these files were intentionally force-added to version the Codex instruction hierarchy.
